### PR TITLE
Fixing potential crash in discover services tx

### DIFF
--- a/src/main/java/com/fitbit/bluetooth/fbgatt/tx/GattClientDiscoverServicesTransaction.java
+++ b/src/main/java/com/fitbit/bluetooth/fbgatt/tx/GattClientDiscoverServicesTransaction.java
@@ -41,7 +41,13 @@ public class GattClientDiscoverServicesTransaction extends GattTransaction {
     protected void transaction(GattTransactionCallback callback) {
         super.transaction(callback);
         getConnection().setState(GattState.DISCOVERING);
-        boolean success = getConnection().getGatt().discoverServices();
+        boolean success;
+        if(getConnection().getGatt() == null) {
+            Timber.w("The gatt was null during discovery, are you sure the connection wasn't cancelled?  Please make sure to handle the transaction results.");
+            success = false;
+        } else {
+            success = getConnection().getGatt().discoverServices();
+        }
         if(!success) {
             getConnection().setState(GattState.DISCOVERY_FAILURE);
             TransactionResult.Builder builder = new TransactionResult.Builder();


### PR DESCRIPTION
If a user has a discover during a disconnection strategy
this could occur. I don't think this should be a strategy
because it's an internal logic issue, I also don't want to do this
everywhere and make it a system thing because it's unlikely to occur
elsewhere.