### PR TITLE
GattConnection#gatt needs to be nullable

### DIFF
--- a/src/main/java/com/fitbit/bluetooth/fbgatt/GattClientCallback.java
+++ b/src/main/java/com/fitbit/bluetooth/fbgatt/GattClientCallback.java
@@ -54,13 +54,17 @@ public class GattClientCallback extends BluetoothGattCallback {
         Looper looper;
         if(context == null || context.getMainLooper() == null) {
             Timber.w("[%s] Um.... you really need to provide a non-null context here, things will work, but you'll have an extra thread running around", Build.DEVICE);
-            HandlerThread gattServerCallbackHandlerThread = new HandlerThread("Default Gatt Client Callback Handler Thread", Thread.NORM_PRIORITY);
-            gattServerCallbackHandlerThread.start();
-            looper = gattServerCallbackHandlerThread.getLooper();
+            HandlerThread gattClientCallbackHandlerThread = new HandlerThread("Default Gatt Client Callback Handler Thread", Thread.NORM_PRIORITY);
+            gattClientCallbackHandlerThread.start();
+            looper = gattClientCallbackHandlerThread.getLooper();
         } else {
             looper = context.getMainLooper();
         }
         this.handler = new Handler(looper);
+    }
+
+    Handler getClientCallbackHandler(){
+        return this.handler;
     }
 
     void addListener(GattClientListener gattListener) {

--- a/src/main/java/com/fitbit/bluetooth/fbgatt/HandleIntentBasedScanResult.java
+++ b/src/main/java/com/fitbit/bluetooth/fbgatt/HandleIntentBasedScanResult.java
@@ -9,6 +9,7 @@
 package com.fitbit.bluetooth.fbgatt;
 
 import android.annotation.TargetApi;
+import android.bluetooth.BluetoothAdapter;
 import android.bluetooth.le.BluetoothLeScanner;
 import android.bluetooth.le.ScanResult;
 import android.bluetooth.le.ScanSettings;
@@ -18,6 +19,7 @@ import android.content.Intent;
 import android.os.Build;
 import android.support.annotation.NonNull;
 
+import com.fitbit.bluetooth.fbgatt.util.GattUtils;
 import com.fitbit.bluetooth.fbgatt.util.ScanFailedReason;
 
 import java.util.List;
@@ -42,9 +44,15 @@ public class HandleIntentBasedScanResult extends BroadcastReceiver {
     @Override
     public void onReceive(Context context, Intent intent) {
         if (intent != null) {
-            if(!FitbitGatt.getInstance().isBluetoothOn()) {
+            // need to use the adapter directly because bitgatt may not have been instantiated
+            BluetoothAdapter adapter = new GattUtils().getBluetoothAdapter(context);
+            if(adapter == null || !adapter.isEnabled()) {
                 Timber.w("Bluetooth is turned off, ignoring");
                 return;
+            }
+            if(!FitbitGatt.getInstance().isStarted()) {
+                Timber.v("Bitgatt wasn't started, starting before handling...");
+                FitbitGatt.getInstance().start(context);
             }
             Timber.v("Received connection update : %s", intent.getAction());
             // added by the system to the intent defined in {@link OreoBackgroundScanner#explicitIntentHelper}
@@ -56,69 +64,90 @@ public class HandleIntentBasedScanResult extends BroadcastReceiver {
                 List<ScanResult> results = intent.getParcelableArrayListExtra(BluetoothLeScanner.EXTRA_LIST_SCAN_RESULT);
                 if (results != null && !results.isEmpty()) {
                     // there are callback results, so now we should do something with this, it's
-                    // OK to do this on the main thread as we aren't doing anything with I/O
+                    // not OK to do this on the main thread so we'll jump onto a scheduler
                     for(ScanResult result : results) {
-                        FitbitBluetoothDevice fitBd = new FitbitBluetoothDevice(result.getDevice());
-                        fitBd.setScanRecord(result.getScanRecord());
-                        fitBd.origin = FitbitBluetoothDevice.DeviceOrigin.SCANNED;
-                        fitBd.setRssi(result.getRssi());
-                        if(FitbitGatt.getInstance().isStarted() && FitbitGatt.getInstance().isScanning()) {
-                            Timber.v("Bitgatt is started and scanning, so we should add %s", fitBd);
-                            FitbitGatt.getInstance().addBackgroundScannedDeviceConnection(fitBd);
-                        } else {
-                            Timber.w("Bitgatt is not started, starting for %s", fitBd);
-                            // this will take us off of the main thread
-                            FitbitGatt.getInstance().registerGattEventListener(new FitbitGatt.FitbitGattCallback() {
-                                @Override
-                                public void onBluetoothPeripheralDiscovered(@NonNull GattConnection connection) {
-
-                                }
-
-                                @Override
-                                public void onBluetoothPeripheralDisconnected(@NonNull GattConnection connection) {
-
-                                }
-
-                                @Override
-                                public void onFitbitGattReady() {
-                                    Timber.v("Bitgatt is started, so we should add %s, but the internal scan state may not be consistent.", fitBd);
+                        FitbitGatt.getInstance().getClientCallback().getClientCallbackHandler().post(() -> {
+                            FitbitBluetoothDevice fitBd = new FitbitBluetoothDevice(result.getDevice());
+                            fitBd.setScanRecord(result.getScanRecord());
+                            fitBd.origin = FitbitBluetoothDevice.DeviceOrigin.SCANNED;
+                            fitBd.setRssi(result.getRssi());
+                            /*
+                             * If bitgatt is started, then we need to determine whether we are still
+                             * pending intent scanning from a different start and set the correct
+                             * state internally.  If we are not started, then is pending intent scanning
+                             * will be false because the scanner will have been null, so the next scan event
+                             * we will enter is started and is pending intent scanning false, so we will
+                             * update the state.
+                             */
+                            if(FitbitGatt.getInstance().isStarted()) {
+                                if(FitbitGatt.getInstance().isPendingIntentScanning()) {
+                                    Timber.v("Bitgatt is started and scanning, so we should add %s", fitBd);
                                     FitbitGatt.getInstance().addBackgroundScannedDeviceConnection(fitBd);
-                                    // after the start is done, we don't want to be a dead-weight
-                                    FitbitGatt.getInstance().unregisterGattEventListener(this);
+                                } else {
+                                    Timber.v("Bitgatt is started, but is not intent scanning, so we may have died in the background adding %s and telling bitgatt that we are still intent scanning", fitBd);
+                                    PeripheralScanner scanner = FitbitGatt.getInstance().getPeripheralScanner();
+                                    if(scanner != null) {
+                                        scanner.setIsPendingIntentScanning(true);
+                                    } else {
+                                        Timber.v("Tried to handle the event and update the scanner's internal state, but the scanner was null");
+                                    }
+                                    FitbitGatt.getInstance().addBackgroundScannedDeviceConnection(fitBd);
                                 }
+                            } else {
+                                Timber.w("Bitgatt is not started, or we aren't pending intent scanning, let's try starting for %s", fitBd);
+                                // this will take us off of the main thread
+                                FitbitGatt.getInstance().registerGattEventListener(new FitbitGatt.FitbitGattCallback() {
+                                    @Override
+                                    public void onBluetoothPeripheralDiscovered(@NonNull GattConnection connection) {
 
-                                @Override
-                                public void onScanStarted() {
+                                    }
 
-                                }
+                                    @Override
+                                    public void onBluetoothPeripheralDisconnected(@NonNull GattConnection connection) {
 
-                                @Override
-                                public void onScanStopped() {
+                                    }
 
-                                }
+                                    @Override
+                                    public void onFitbitGattReady() {
+                                        Timber.v("Bitgatt is started, so we should add %s, but the internal scan state may not be consistent.", fitBd);
+                                        FitbitGatt.getInstance().addBackgroundScannedDeviceConnection(fitBd);
+                                        // after the start is done, we don't want to be a dead-weight
+                                        FitbitGatt.getInstance().unregisterGattEventListener(this);
+                                    }
 
-                                @Override
-                                public void onPendingIntentScanStopped() {
+                                    @Override
+                                    public void onScanStarted() {
 
-                                }
+                                    }
 
-                                @Override
-                                public void onPendingIntentScanStarted() {
+                                    @Override
+                                    public void onScanStopped() {
 
-                                }
+                                    }
 
-                                @Override
-                                public void onBluetoothOff() {
+                                    @Override
+                                    public void onPendingIntentScanStopped() {
 
-                                }
+                                    }
 
-                                @Override
-                                public void onBluetoothOn() {
+                                    @Override
+                                    public void onPendingIntentScanStarted() {
 
-                                }
-                            });
-                            FitbitGatt.getInstance().start(context);
-                        }
+                                    }
+
+                                    @Override
+                                    public void onBluetoothOff() {
+
+                                    }
+
+                                    @Override
+                                    public void onBluetoothOn() {
+
+                                    }
+                                });
+                                FitbitGatt.getInstance().start(context);
+                            }
+                        });
                     }
                 } else {
                     Timber.w("Scan callback with no results");

--- a/src/main/java/com/fitbit/bluetooth/fbgatt/strategies/HandleTrackerVanishingUnderGattOperationStrategy.java
+++ b/src/main/java/com/fitbit/bluetooth/fbgatt/strategies/HandleTrackerVanishingUnderGattOperationStrategy.java
@@ -13,6 +13,8 @@ import com.fitbit.bluetooth.fbgatt.FitbitGatt;
 import com.fitbit.bluetooth.fbgatt.GattConnection;
 import com.fitbit.bluetooth.fbgatt.GattState;
 
+import android.bluetooth.BluetoothGatt;
+
 import java.util.concurrent.TimeUnit;
 
 import timber.log.Timber;
@@ -36,7 +38,12 @@ public class HandleTrackerVanishingUnderGattOperationStrategy extends Strategy {
         Timber.d("Applying tracker vanishing while in gatt operation strategy");
         if(connection != null) {
             connection.setState(GattState.DISCONNECTING);
-            connection.getGatt().disconnect();
+            BluetoothGatt localGatt = connection.getGatt();
+            if(localGatt != null) {
+                localGatt.disconnect();
+            } else {
+                Timber.d("Could not apply strategy because the gatt was null");
+            }
         }
         // we might not get the gatt disconnect callback if the if is lost,
         // so in this scenario we will have to wait for the client_if to dump for sure,

--- a/src/main/java/com/fitbit/bluetooth/fbgatt/tx/CloseGattTransaction.java
+++ b/src/main/java/com/fitbit/bluetooth/fbgatt/tx/CloseGattTransaction.java
@@ -14,6 +14,7 @@ import com.fitbit.bluetooth.fbgatt.GattTransaction;
 import com.fitbit.bluetooth.fbgatt.GattTransactionCallback;
 import com.fitbit.bluetooth.fbgatt.TransactionResult;
 
+import android.bluetooth.BluetoothGatt;
 import android.support.annotation.Nullable;
 
 import timber.log.Timber;
@@ -38,9 +39,10 @@ public class CloseGattTransaction extends GattTransaction {
     protected void transaction(GattTransactionCallback callback) {
         super.transaction(callback);
         getConnection().setState(GattState.CLOSING_GATT_CLIENT);
-        if(getConnection().getGatt() != null) {
+        BluetoothGatt localGatt = getConnection().getGatt();
+        if(localGatt != null) {
             try {
-                getConnection().getGatt().close();
+                localGatt.close();
                 getConnection().justClearGatt();
             } catch (NullPointerException e) {
                 Timber.w(e, "[%s] If the underlying connection is gone, on some platforms, this can throw an NPE", getConnection().getDevice());

--- a/src/main/java/com/fitbit/bluetooth/fbgatt/tx/GattClientDiscoverServicesTransaction.java
+++ b/src/main/java/com/fitbit/bluetooth/fbgatt/tx/GattClientDiscoverServicesTransaction.java
@@ -42,11 +42,12 @@ public class GattClientDiscoverServicesTransaction extends GattTransaction {
         super.transaction(callback);
         getConnection().setState(GattState.DISCOVERING);
         boolean success;
-        if(getConnection().getGatt() == null) {
+        BluetoothGatt localGatt = getConnection().getGatt();
+        if(localGatt == null) {
             Timber.w("The gatt was null during discovery, are you sure the connection wasn't cancelled?  Please make sure to handle the transaction results.");
             success = false;
         } else {
-            success = getConnection().getGatt().discoverServices();
+            success = localGatt.discoverServices();
         }
         if(!success) {
             getConnection().setState(GattState.DISCOVERY_FAILURE);

--- a/src/main/java/com/fitbit/bluetooth/fbgatt/tx/GattDisconnectTransaction.java
+++ b/src/main/java/com/fitbit/bluetooth/fbgatt/tx/GattDisconnectTransaction.java
@@ -54,9 +54,20 @@ public class GattDisconnectTransaction extends GattTransaction {
         if(getDevice() != null && !new GattUtils().
                 isPerhipheralCurrentlyConnectedToPhone(FitbitGatt.getInstance().getAppContext(),
                         getDevice().getBtDevice())) {
-            onConnectionStateChange(getConnection().getGatt(),
+            BluetoothGatt localGatt = getConnection().getGatt();
+            if(localGatt != null) {
+                onConnectionStateChange(localGatt,
                     BluetoothGatt.GATT_SUCCESS,
                     BluetoothProfile.STATE_DISCONNECTED);
+            } else {
+                Timber.w("The gatt was already null");
+                TransactionResult.Builder builder = new TransactionResult.Builder().transactionName(getName());
+                getConnection().setState(GattState.DISCONNECTED);
+                builder.resultStatus(TransactionResult.TransactionResultStatus.SUCCESS)
+                    .rssi(getConnection().getDevice().getRssi())
+                    .gattState(getConnection().getGattState());
+                callCallbackWithTransactionResultAndRelease(callback, builder.build());
+            }
         } else {
             getConnection().disconnect();
         }

--- a/src/main/java/com/fitbit/bluetooth/fbgatt/tx/ReadGattDescriptorTransaction.java
+++ b/src/main/java/com/fitbit/bluetooth/fbgatt/tx/ReadGattDescriptorTransaction.java
@@ -49,33 +49,38 @@ public class ReadGattDescriptorTransaction extends GattTransaction {
     protected void transaction(GattTransactionCallback callback) {
         super.transaction(callback);
         getConnection().setState(GattState.READING_DESCRIPTOR);
-        boolean success;
-        try {
-            success = getConnection().getGatt().readDescriptor(descriptor);
-        } catch (NullPointerException ex) {
-            Timber.w(ex,"[%s] We are going to fail this tx due to the stack NPE, this is probably poor peripheral behavior, this should become a FW bug.", getDevice());
-            if(getDevice() != null) {
-                Timber.w("[%s] btDevice %s characteristic %s", getDevice(), getDevice().getBtDevice(), this.descriptor.getUuid());
+        boolean success = false;
+        BluetoothGatt localGatt = getConnection().getGatt();
+        if(localGatt != null) {
+            try {
+                success = localGatt.readDescriptor(descriptor);
+            } catch (NullPointerException ex) {
+                Timber.w(ex, "[%s] We are going to fail this tx due to the stack NPE, this is probably poor peripheral behavior, this should become a FW bug.", getDevice());
+                if (getDevice() != null) {
+                    Timber.w("[%s] btDevice %s characteristic %s", getDevice(), getDevice().getBtDevice(), this.descriptor.getUuid());
+                }
+                // Ensure that the flag is set to false, and that is is
+                // impossible to be anything else stepping through after
+                // this ... strategy time
+                success = false;
             }
-            // Ensure that the flag is set to false, and that is is
-            // impossible to be anything else stepping through after
-            // this ... strategy time
-            success = false;
+        } else {
+            Timber.w("Couldn't read descriptor because gatt was null");
         }
         TransactionResult.Builder builder = new TransactionResult.Builder().transactionName(getName());
-        if(!success) {
+        if (!success) {
             getConnection().setState(GattState.READ_DESCRIPTOR_FAILURE);
             builder.resultStatus(TransactionResult.TransactionResultStatus.FAILURE)
-                    .gattState(getConnection().getGattState());
+                .gattState(getConnection().getGattState());
             mainThreadHandler.post(() -> {
                 callCallbackWithTransactionResultAndRelease(callback, builder.build());
                 getConnection().setState(GattState.IDLE);
                 // we want to apply this strategy to every phone, so we will provide an empty target android
                 // device
                 Strategy strategy = strategyProvider.
-                        getStrategyForPhoneAndGattConnection(null, getConnection(),
-                                Situation.TRACKER_WENT_AWAY_DURING_GATT_OPERATION);
-                if(strategy != null) {
+                    getStrategyForPhoneAndGattConnection(null, getConnection(),
+                        Situation.TRACKER_WENT_AWAY_DURING_GATT_OPERATION);
+                if (strategy != null) {
                     strategy.applyStrategy();
                 }
             });

--- a/src/main/java/com/fitbit/bluetooth/fbgatt/tx/ReadRssiTransaction.java
+++ b/src/main/java/com/fitbit/bluetooth/fbgatt/tx/ReadRssiTransaction.java
@@ -40,7 +40,11 @@ public class ReadRssiTransaction extends GattTransaction {
     protected void transaction(GattTransactionCallback callback) {
         super.transaction(callback);
         getConnection().setState(GattState.READING_RSSI);
-        boolean success = getConnection().getGatt().readRemoteRssi();
+        BluetoothGatt localGatt = getConnection().getGatt();
+        boolean success = false;
+        if(localGatt != null) {
+            success = localGatt.readRemoteRssi();
+        }
         if(!success) {
             getConnection().setState(GattState.READ_RSSI_FAILURE);
             TransactionResult.Builder builder = new TransactionResult.Builder().transactionName(getName());

--- a/src/main/java/com/fitbit/bluetooth/fbgatt/tx/RequestGattConnectionIntervalTransaction.java
+++ b/src/main/java/com/fitbit/bluetooth/fbgatt/tx/RequestGattConnectionIntervalTransaction.java
@@ -19,6 +19,8 @@ import com.fitbit.bluetooth.fbgatt.util.GattStatus;
 import android.bluetooth.BluetoothGatt;
 import android.support.annotation.Nullable;
 
+import timber.log.Timber;
+
 import static android.os.Build.VERSION_CODES.LOLLIPOP;
 
 /**
@@ -69,9 +71,14 @@ public class RequestGattConnectionIntervalTransaction extends GattTransaction {
         getConnection().setState(GattState.REQUESTING_CONNECTION_INTERVAL_CHANGE);
         TransactionResult.Builder builder = new TransactionResult.Builder().transactionName(getName());
         builder.resultStatus(TransactionResult.TransactionResultStatus.FAILURE);
-        boolean success;
+        boolean success = false;
         if(FitbitGatt.atLeastSDK(LOLLIPOP)) {
-            success = getConnection().getGatt().requestConnectionPriority(speed.getConnectionPriority());
+            BluetoothGatt localGatt = getConnection().getGatt();
+            if(localGatt != null) {
+                success = localGatt.requestConnectionPriority(speed.getConnectionPriority());
+            } else {
+                Timber.w("Couldn't request connection priority because gatt was null");
+            }
             if(!success) {
                 getConnection().setState(GattState.REQUEST_CONNECTION_INTERVAL_FAILURE);
                 builder.responseStatus(GattStatus.GATT_NO_RESOURCES.getCode());

--- a/src/main/java/com/fitbit/bluetooth/fbgatt/tx/RequestMtuGattTransaction.java
+++ b/src/main/java/com/fitbit/bluetooth/fbgatt/tx/RequestMtuGattTransaction.java
@@ -49,8 +49,14 @@ public class RequestMtuGattTransaction extends GattTransaction {
     protected void transaction(GattTransactionCallback callback) {
         super.transaction(callback);
         getConnection().setState(GattState.REQUESTING_MTU);
+        boolean success = false;
         if(FitbitGatt.atLeastSDK(LOLLIPOP)) {
-            boolean success = getConnection().getGatt().requestMtu(this.mtu);
+            BluetoothGatt localGatt = getConnection().getGatt();
+            if(localGatt != null) {
+                success = localGatt.requestMtu(this.mtu);
+            } else {
+                Timber.w("Couldn't request a new MTU because the gatt was null");
+            }
             if(success) {
                 return;
             }

--- a/src/main/java/com/fitbit/bluetooth/fbgatt/tx/WriteGattCharacteristicTransaction.java
+++ b/src/main/java/com/fitbit/bluetooth/fbgatt/tx/WriteGattCharacteristicTransaction.java
@@ -51,18 +51,23 @@ public class WriteGattCharacteristicTransaction extends GattTransaction {
     protected void transaction(GattTransactionCallback callback) {
         super.transaction(callback);
         getConnection().setState(GattState.WRITING_CHARACTERISTIC);
-        boolean success;
-        try {
-            success = getConnection().getGatt().writeCharacteristic(characteristic);
-        } catch (NullPointerException ex) {
-            Timber.w(ex,"[%s] We are going to fail this tx due to the stack NPE, this is probably poor peripheral behavior, this should become a FW bug.", getDevice());
-            if(getDevice() != null) {
-                Timber.w("[%s] btDevice %s characteristic %s", getDevice(), getDevice().getBtDevice(), this.characteristic.getUuid());
+        boolean success = false;
+        BluetoothGatt localGatt = getConnection().getGatt();
+        if(localGatt != null) {
+            try {
+                success = localGatt.writeCharacteristic(characteristic);
+            } catch (NullPointerException ex) {
+                Timber.w(ex, "[%s] We are going to fail this tx due to the stack NPE, this is probably poor peripheral behavior, this should become a FW bug.", getDevice());
+                if (getDevice() != null) {
+                    Timber.w("[%s] btDevice %s characteristic %s", getDevice(), getDevice().getBtDevice(), this.characteristic.getUuid());
+                }
+                // Ensure that the flag is set to false, and that is is
+                // impossible to be anything else stepping through after
+                // this ... strategy time
+                success = false;
             }
-            // Ensure that the flag is set to false, and that is is
-            // impossible to be anything else stepping through after
-            // this ... strategy time
-            success = false;
+        } else {
+            Timber.w("Can't write characteristic because gatt was null");
         }
         TransactionResult.Builder builder = new TransactionResult.Builder().transactionName(getName());
         if(!success) {


### PR DESCRIPTION
Because we can apply a strategy after events that leave
the gatt null, we must handle this condition everywhere