### PR TITLE
Prevent flapping and correct binder callback issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,12 @@ are not implemented.  Bitgatt will respond with error ( to help prevent disconne
 where the developer has not registered a listener, or where they are not using a particular
 characteristic.
 
+In order to ensure that the gatt server is always responsive after toggling bluetooth services will
+be cleared when BT is disabled, this leads to a consistent experience across Android devices.  In
+order to use services again, please re-add any gatt server services that you are hosting on the
+Android device when BT is turned on again.  You can do this by listening for bt on / off events 
+with the FitbitGattCallback.
+
 ## [Sample Code](#sample-code)
 
 Pre-Commit ( Deprecated )

--- a/src/debug/java/com/fitbit/tools/GattPlugin.java
+++ b/src/debug/java/com/fitbit/tools/GattPlugin.java
@@ -2482,6 +2482,16 @@ public class GattPlugin implements DumperPlugin, FitbitGatt.FitbitGattCallback, 
     }
 
     @Override
+    public void onBluetoothTurningOn() {
+        Timber.v("Bluetooth turning on was called");
+    }
+
+    @Override
+    public void onBluetoothTurningOff() {
+        Timber.v("Bluetooth turning off was called");
+    }
+
+    @Override
     public void onBluetoothPeripheralDevicePropertiesChanged(FitbitBluetoothDevice device) {
         Map<String, Object> map = new LinkedHashMap<>();
         map.put("mac", device.getAddress());

--- a/src/main/java/com/fitbit/bluetooth/fbgatt/BluetoothRadioStatusListener.java
+++ b/src/main/java/com/fitbit/bluetooth/fbgatt/BluetoothRadioStatusListener.java
@@ -8,31 +8,63 @@
 
 package com.fitbit.bluetooth.fbgatt;
 
+import com.fitbit.bluetooth.fbgatt.util.GattUtils;
+
 import android.bluetooth.BluetoothAdapter;
 import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
+import android.os.Handler;
+import android.os.Looper;
+import android.os.SystemClock;
 import android.support.annotation.VisibleForTesting;
 
 import timber.log.Timber;
 
 /**
  * Responsible for listening to the broadcasts of the bluetooth radio status on the mobile device
- * and notifying a callback
- *
+ * and notifying a callback.  This listener will also attempt to prevent flapping in the case that
+ * the user is rapidly toggling bluetooth on and off.
+ * <p>
  * Created by iowens on 8/27/18.
  */
 class BluetoothRadioStatusListener {
+    @VisibleForTesting
+    static final long MIN_TURNING_OFF_CALLBACK_DELAY = 500;
+    static final long MIN_TURNING_ON_CALLBACK_DELAY = 1000;
+    private Handler mainHandler;
+    private int currentState;
+    private long lastEvent = SystemClock.elapsedRealtimeNanos();
+
+    @VisibleForTesting
+    BluetoothRadioStatusListener(Context context, boolean shouldInitializeListening, Looper mockMainThreadLooper) {
+        this.context = context;
+        // this handler is to deliver the callbacks in the same way as they would usually
+        // be delivered, but we want to avoid flapping ( user toggling on and off quickly )
+        // so that our protocol stacks do not get set up in a half state
+        this.mainHandler = new Handler(mockMainThreadLooper);
+        if (shouldInitializeListening) {
+            Timber.d("Starting listener");
+            startListening();
+        }
+        // we are testing, default to BT on
+        currentState = BluetoothAdapter.STATE_ON;
+    }
+
     /**
      * The delegate interface for changes on the radio status
      */
     interface BluetoothOnListener {
         void bluetoothOff();
+
         void bluetoothOn();
+
         void bluetoothTurningOff();
+
         void bluetoothTurningOn();
     }
+
     /**
      * The android context
      */
@@ -51,36 +83,73 @@ class BluetoothRadioStatusListener {
             if (BluetoothAdapter.ACTION_STATE_CHANGED.equals(intent.getAction())) {
                 final int state = intent.getIntExtra(BluetoothAdapter.EXTRA_STATE, BluetoothAdapter.ERROR);
                 Timber.d("Received BluetoothState: [%s]", parseBluetoothStatus(state));
-                switch (state) {
-                    case BluetoothAdapter.STATE_OFF:
-                        if(listener != null){
-                            listener.bluetoothOff();
+                performActionIfNecessaryAndUpdateState(state);
+            }
+        }
+
+        private void performActionIfNecessaryAndUpdateState(int state) {
+            // if a dev wants to know about flapping listen to turning on / off
+            if (state == BluetoothAdapter.STATE_TURNING_ON || state == BluetoothAdapter.STATE_TURNING_OFF) {
+                Timber.v("Turning off or turning on, passing through with no delay");
+                mainHandler.post(() -> {
+                    if (listener != null) {
+                        switch (state) {
+                            case BluetoothAdapter.STATE_TURNING_OFF:
+                                listener.bluetoothTurningOff();
+                                break;
+                            case BluetoothAdapter.STATE_TURNING_ON:
+                                listener.bluetoothTurningOn();
+                                break;
+                            default:
+                                Timber.w("The BT radio went into a state that we do not handle");
                         }
-                        break;
-                    case BluetoothAdapter.STATE_ON:
-                        if(listener != null) {
-                            listener.bluetoothOn();
+                    }
+                });
+            } else {
+                boolean shouldCallback = shouldScheduleCallback(currentState, state);
+                currentState = state;
+                if (shouldCallback) {
+                    // if we got that we should callback, then we should cancel any existing pending
+                    // callback before starting the new one
+                    mainHandler.removeCallbacksAndMessages(null);
+                    Timber.v("Clearing old messages");
+                    Timber.v("BT on or off, sending after %dms", (state == BluetoothAdapter.STATE_OFF) ? MIN_TURNING_OFF_CALLBACK_DELAY : MIN_TURNING_ON_CALLBACK_DELAY);
+                    mainHandler.postDelayed(() -> {
+                        if (listener != null) {
+                            switch (state) {
+                                case BluetoothAdapter.STATE_OFF:
+                                    Timber.v("Notifying off");
+                                    listener.bluetoothOff();
+                                    break;
+                                case BluetoothAdapter.STATE_ON:
+                                    Timber.v("Notifying on");
+                                    listener.bluetoothOn();
+                                    break;
+                                default:
+                                    Timber.w("The BT radio went into a state that we do not handle");
+                            }
                         }
-                        break;
-                    case BluetoothAdapter.STATE_TURNING_OFF:
-                        if(listener != null) {
-                            listener.bluetoothTurningOff();
-                        }
-                        break;
-                    case BluetoothAdapter.STATE_TURNING_ON:
-                        if(listener != null) {
-                            listener.bluetoothTurningOn();
-                        }
-                        break;
-                    default:
-                        Timber.w("The BT radio went into a state that we do not handle");
+                    }, ((state == BluetoothAdapter.STATE_OFF) ? MIN_TURNING_OFF_CALLBACK_DELAY : MIN_TURNING_ON_CALLBACK_DELAY));
+                } else {
+                    Timber.d("Not calling back, flapping");
                 }
             }
         }
     };
 
+    @VisibleForTesting
+    void setCurrentState(int currentAdapterState) {
+        this.currentState = currentAdapterState;
+    }
+
+    @VisibleForTesting
+    void setLastEvent(long lastEventTime) {
+        this.lastEvent = lastEventTime;
+    }
+
     /**
      * To set a delegate for listening to bluetooth adapter state changes on this class
+     *
      * @param onListener The listener for status changes
      */
 
@@ -97,13 +166,21 @@ class BluetoothRadioStatusListener {
 
     /**
      * Constructor for the listener, if desired as a convenience can start listening immediately
-     * @param context The android context
+     *
+     * @param context                   The android context
      * @param shouldInitializeListening Whether to attach to the global broadcast immediately
      */
 
     BluetoothRadioStatusListener(Context context, boolean shouldInitializeListening) {
         this.context = context;
-        if(shouldInitializeListening) {
+        BluetoothAdapter adapter = new GattUtils().getBluetoothAdapter(context);
+        // if we are in this condition, something is seriously wrong
+        this.currentState = (adapter != null) ? adapter.getState() : BluetoothAdapter.STATE_OFF;
+        // this handler is to deliver the callbacks in the same way as they would usually
+        // be delivered, but we want to avoid flapping ( user toggling on and off quickly )
+        // so that our protocol stacks do not get set up in a half state
+        this.mainHandler = new Handler(Looper.getMainLooper());
+        if (shouldInitializeListening) {
             Timber.d("Starting listener");
             startListening();
         }
@@ -113,7 +190,7 @@ class BluetoothRadioStatusListener {
      * Will start listening to the global bluetooth adapter broadcasts
      */
 
-    void startListening(){
+    void startListening() {
         IntentFilter filter = new IntentFilter(BluetoothAdapter.ACTION_STATE_CHANGED);
         context.getApplicationContext().registerReceiver(receiver, filter);
     }
@@ -122,19 +199,20 @@ class BluetoothRadioStatusListener {
      * Will stop listening to the global bluetooth adapter status broadcasts
      */
 
-    void stopListening(){
+    void stopListening() {
         context.getApplicationContext().unregisterReceiver(receiver);
     }
 
     /**
      * Will parse out the bluetooth status integer into actual text to log
+     *
      * @param status The bluetooth status value from the intent
      * @return The string value of the bluetooth status response
      */
 
     private String parseBluetoothStatus(int status) {
         String statusString;
-        switch(status) {
+        switch (status) {
             case BluetoothAdapter.STATE_TURNING_ON:
                 statusString = "Turning On";
                 break;
@@ -152,6 +230,57 @@ class BluetoothRadioStatusListener {
                 break;
         }
         return statusString;
+    }
+
+    /**
+     * What this method does is to determine, based on a stream of inputs whether to schedule an
+     * on / off callback ( we'll leave the turning on / turning off callbacks alone ).  What we want
+     * is to send an off callback immediately, but only send an on callback if the state has
+     * settled into an on state for one second.
+     *
+     * Turning off and turning on are not considered by this logic
+     *
+     * @param previousState The previous bt state
+     * @param currentState  The current bt state
+     * @return true if a callback should be scheduled based on the current state, false if nothing should occur
+     */
+    @VisibleForTesting
+    boolean shouldScheduleCallback(int previousState, int currentState) {
+        boolean shouldReturn;
+        long currentRt = SystemClock.elapsedRealtimeNanos();
+        // this method should not hold it's own state, but instead operate on the values provided
+        // for now we will just write it out and then test the crap out of it to make sure that
+        // all cases are handled.
+        // check less than MIN_CALLBACK_DELAY, if less than say no, there is a minor edge case where
+        // currentRt and lastEvent can be the same nanos, if this is true, just do nothing since
+        // the app just launched and the toggle is already happening, this is flapping too.
+        if (currentRt - lastEvent < ((currentState == BluetoothAdapter.STATE_OFF) ? MIN_TURNING_OFF_CALLBACK_DELAY : MIN_TURNING_ON_CALLBACK_DELAY)) {
+            Timber.d("Time since last BT radio change is less than min, not doing anything");
+            return false;
+        }
+        if (previousState == BluetoothAdapter.STATE_ON && currentState == BluetoothAdapter.STATE_OFF) {
+            // we always want to send a message when the adapter goes off
+            Timber.v("The adapter is off");
+            shouldReturn = true;
+        } else if (previousState == BluetoothAdapter.STATE_ON && currentState == BluetoothAdapter.STATE_ON) {
+            // this is here for just completeness, realistically this should never happen
+            Timber.v("The adapter was on and somehow we got on again, sad.");
+            shouldReturn = false;
+        } else if (previousState == BluetoothAdapter.STATE_OFF && currentState == BluetoothAdapter.STATE_OFF) {
+            // likewise, this should never happen
+            Timber.v("We are in a state that should never occur, this phone may have an untrustworthy BT stack");
+            shouldReturn = false;
+        } else if (previousState == BluetoothAdapter.STATE_OFF && currentState == BluetoothAdapter.STATE_ON) {
+            Timber.v("Adapter was off and is on");
+            shouldReturn = true;
+        } else {
+            Timber.v("Unknown state");
+            shouldReturn = false;
+        }
+        // we want elapsed real-time millis because the user could be doing funky things with
+        // SystemClock sleep or whatever
+        lastEvent = SystemClock.elapsedRealtimeNanos();
+        return shouldReturn;
     }
 }
 

--- a/src/main/java/com/fitbit/bluetooth/fbgatt/GattTransactionCallback.java
+++ b/src/main/java/com/fitbit/bluetooth/fbgatt/GattTransactionCallback.java
@@ -8,6 +8,7 @@
 
 package com.fitbit.bluetooth.fbgatt;
 
+import android.support.annotation.MainThread;
 import android.support.annotation.NonNull;
 
 /**
@@ -18,5 +19,6 @@ import android.support.annotation.NonNull;
  */
 
 public interface GattTransactionCallback {
+    @MainThread
     void onTransactionComplete(@NonNull TransactionResult result);
 }

--- a/src/main/java/com/fitbit/bluetooth/fbgatt/HandleIntentBasedScanResult.java
+++ b/src/main/java/com/fitbit/bluetooth/fbgatt/HandleIntentBasedScanResult.java
@@ -144,6 +144,16 @@ public class HandleIntentBasedScanResult extends BroadcastReceiver {
                                     public void onBluetoothOn() {
 
                                     }
+
+                                    @Override
+                                    public void onBluetoothTurningOn() {
+
+                                    }
+
+                                    @Override
+                                    public void onBluetoothTurningOff() {
+
+                                    }
                                 });
                                 FitbitGatt.getInstance().start(context);
                             }

--- a/src/test/java/com/fitbit/bluetooth/fbgatt/BluetoothAdapterStatusTests.java
+++ b/src/test/java/com/fitbit/bluetooth/fbgatt/BluetoothAdapterStatusTests.java
@@ -161,6 +161,16 @@ public class BluetoothAdapterStatusTests {
             @Override
             public void onBluetoothOn() {
             }
+
+            @Override
+            public void onBluetoothTurningOn() {
+
+            }
+
+            @Override
+            public void onBluetoothTurningOff() {
+
+            }
         });
         FitbitGatt.getInstance().registerGattEventListener(cb);
         mockStatusListener.listener = FitbitGatt.getInstance();
@@ -221,6 +231,16 @@ public class BluetoothAdapterStatusTests {
 
             @Override
             public void onBluetoothOn() {
+
+            }
+
+            @Override
+            public void onBluetoothTurningOn() {
+
+            }
+
+            @Override
+            public void onBluetoothTurningOff() {
 
             }
         });

--- a/src/test/java/com/fitbit/bluetooth/fbgatt/BluetoothRadioStatusListenerTest.java
+++ b/src/test/java/com/fitbit/bluetooth/fbgatt/BluetoothRadioStatusListenerTest.java
@@ -1,0 +1,534 @@
+/*
+ * Copyright 2019 Fitbit, Inc. All rights reserved.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+package com.fitbit.bluetooth.fbgatt;
+
+import android.bluetooth.BluetoothAdapter;
+import android.content.Context;
+import android.content.Intent;
+import android.os.Handler;
+import android.os.Looper;
+import android.os.SystemClock;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.stubbing.Answer;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+import static junit.framework.TestCase.assertFalse;
+import static junit.framework.TestCase.assertTrue;
+import static junit.framework.TestCase.fail;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class BluetoothRadioStatusListenerTest {
+
+    private BluetoothRadioStatusListener statusListener;
+    private ScheduledExecutorService singleThreadExecutor = Executors.newSingleThreadScheduledExecutor();
+    private Context ctx;
+    private Handler mockHandler;
+    private Answer<Boolean> handlerPostAnswer = invocation -> {
+        Long delay = 0L;
+        if (invocation.getArguments().length > 1) {
+            delay = invocation.getArgument(1);
+        }
+        Runnable msg = invocation.getArgument(0);
+        if (msg != null) {
+            singleThreadExecutor.schedule(msg, delay, TimeUnit.MILLISECONDS);
+        }
+        return true;
+    };
+
+    @Before
+    public void before(){
+        Looper mockMainThreadLooper = mock(Looper.class);
+        Thread mockMainThread = mock(Thread.class);
+        when(mockMainThread.getName()).thenReturn("Irvin's mock thread");
+        when(mockMainThreadLooper.getThread()).thenReturn(mockMainThread);
+        ctx = mock(Context.class);
+        when(ctx.getApplicationContext()).thenReturn(ctx);
+        when(ctx.getMainLooper()).thenReturn(mockMainThreadLooper);
+        FitbitGatt.getInstance().start(ctx);
+        mockHandler = mock(Handler.class);
+        doAnswer(handlerPostAnswer).when(mockHandler).post(any(Runnable.class));
+        doAnswer(handlerPostAnswer).when(mockHandler).postDelayed(any(Runnable.class), anyLong());
+        when(mockHandler.getLooper()).thenReturn(mockMainThreadLooper);
+        statusListener = new BluetoothRadioStatusListener(ctx, false, mockMainThreadLooper);
+    }
+
+    // simple case, if state is off and it goes to on, should return true
+    @Test
+    public void testShouldScheduleCallbackBtOffToBtOn(){
+        // assume not flapping
+        statusListener.setLastEvent(SystemClock.elapsedRealtimeNanos() - BluetoothRadioStatusListener.MIN_TURNING_ON_CALLBACK_DELAY);
+        boolean result = statusListener.shouldScheduleCallback(BluetoothAdapter.STATE_OFF, BluetoothAdapter.STATE_ON);
+        assertTrue(result);
+    }
+
+    // simple case, if state is on and it goes to off, should return true
+    @Test
+    public void testShouldScheduleCallbackBtOnToBtOff(){
+        // assume not flapping
+        statusListener.setLastEvent(SystemClock.elapsedRealtimeNanos() - BluetoothRadioStatusListener.MIN_TURNING_OFF_CALLBACK_DELAY);
+        boolean result = statusListener.shouldScheduleCallback(BluetoothAdapter.STATE_ON, BluetoothAdapter.STATE_OFF);
+        assertTrue(result);
+    }
+
+    @Test
+    public void testShouldCallbackForBluetoothTurningOnToTurningOnSomehow(){
+        statusListener.setLastEvent(SystemClock.elapsedRealtimeNanos() - BluetoothRadioStatusListener.MIN_TURNING_ON_CALLBACK_DELAY);
+        boolean result = statusListener.shouldScheduleCallback(BluetoothAdapter.STATE_ON, BluetoothAdapter.STATE_ON);
+        assertFalse(result);
+    }
+
+    @Test
+    public void testShouldCallbackForBluetoothTurningOffToTurningOffSomehow(){
+        statusListener.setLastEvent(SystemClock.elapsedRealtimeNanos() - BluetoothRadioStatusListener.MIN_TURNING_OFF_CALLBACK_DELAY);
+        boolean result = statusListener.shouldScheduleCallback(BluetoothAdapter.STATE_OFF, BluetoothAdapter.STATE_OFF);
+        assertFalse(result);
+    }
+
+    @Test
+    public void flappingTestToggleThreeTimesInLessThanASecondFromOnToOff(){
+        boolean result;
+        boolean onOrOff = false;
+        for(int i=0; i <= 4; i++) {
+            result = statusListener.shouldScheduleCallback(onOrOff ? BluetoothAdapter.STATE_ON : BluetoothAdapter.STATE_OFF,
+                onOrOff ? BluetoothAdapter.STATE_OFF : BluetoothAdapter.STATE_ON);
+            assertFalse(result);
+            onOrOff = !onOrOff;
+        }
+    }
+
+    @Test
+    public void flappingTestToggleTwiceInMoreThanASecondFromOffToOn() {
+        boolean result = false;
+        // assume not flapping at start
+        statusListener.setLastEvent(SystemClock.elapsedRealtimeNanos() - BluetoothRadioStatusListener.MIN_TURNING_OFF_CALLBACK_DELAY);
+        boolean onOrOff = true;
+        for(int i=0; i <= 2; i++) {
+            result = statusListener.shouldScheduleCallback(onOrOff ? BluetoothAdapter.STATE_ON : BluetoothAdapter.STATE_OFF,
+                onOrOff ? BluetoothAdapter.STATE_OFF : BluetoothAdapter.STATE_ON);
+            statusListener.setLastEvent(SystemClock.elapsedRealtimeNanos() - BluetoothRadioStatusListener.MIN_TURNING_ON_CALLBACK_DELAY);
+            onOrOff = !onOrOff;
+        }
+        assertTrue(result);
+    }
+
+    @Test
+    public void flappingTestToggleTwiceInLessThanASecondFromOffToOn() {
+        boolean result = false;
+        // assume not flapping at start
+        statusListener.setLastEvent(SystemClock.elapsedRealtimeNanos() - BluetoothRadioStatusListener.MIN_TURNING_ON_CALLBACK_DELAY);
+        boolean onOrOff = true;
+        for(int i=0; i <= 2; i++) {
+            result = statusListener.shouldScheduleCallback(onOrOff ? BluetoothAdapter.STATE_ON : BluetoothAdapter.STATE_OFF,
+                onOrOff ? BluetoothAdapter.STATE_OFF : BluetoothAdapter.STATE_ON);
+            statusListener.setLastEvent(SystemClock.elapsedRealtimeNanos() - ( BluetoothRadioStatusListener.MIN_TURNING_OFF_CALLBACK_DELAY - (BluetoothRadioStatusListener.MIN_TURNING_OFF_CALLBACK_DELAY / 2 )));
+            onOrOff = !onOrOff;
+        }
+        assertFalse(result);
+    }
+
+    /**
+     * Test typical case, bluetooth was off when app was started, user turns it on
+     */
+    @Test
+    public void testBluetoothOnCallbackShouldHappenAfterDelay() throws InterruptedException {
+        // assume not flapping at start
+        // statusListener.setLastEvent(SystemClock.elapsedRealtimeNanos() - BluetoothRadioStatusListener.MIN_CALLBACK_DELAY);
+        // assume BT was off
+        statusListener.setCurrentState(BluetoothAdapter.STATE_OFF);
+        final long startTime = SystemClock.elapsedRealtime();
+        CountDownLatch cdl = new CountDownLatch(1);
+        statusListener.setListener(new BluetoothRadioStatusListener.BluetoothOnListener() {
+            @Override
+            public void bluetoothOff() {
+                fail();
+            }
+
+            @Override
+            public void bluetoothOn() {
+                long endTime = SystemClock.elapsedRealtime();
+                assertTrue(endTime - startTime >= BluetoothRadioStatusListener.MIN_TURNING_ON_CALLBACK_DELAY);
+                cdl.countDown();
+            }
+
+            @Override
+            public void bluetoothTurningOff() {
+                fail();
+            }
+
+            @Override
+            public void bluetoothTurningOn() {
+                fail();
+            }
+        });
+        // bluetooth on intent
+        Intent i = new Intent(BluetoothAdapter.ACTION_STATE_CHANGED);
+        i.putExtra(BluetoothAdapter.EXTRA_STATE, BluetoothAdapter.STATE_ON);
+        statusListener.receiver.onReceive(ctx, i);
+        cdl.await(2, TimeUnit.SECONDS);
+        statusListener.removeListener();
+    }
+
+    /**
+     * Test typical case, bluetooth was on when app was started, user turns it off
+     */
+    @Test
+    public void testBluetoothOffCallbackShouldHappenWithNoDelay() throws InterruptedException {
+        // assume BT was off
+        statusListener.setCurrentState(BluetoothAdapter.STATE_ON);
+        final long startTime = SystemClock.elapsedRealtime();
+        CountDownLatch cdl = new CountDownLatch(1);
+        statusListener.setListener(new BluetoothRadioStatusListener.BluetoothOnListener() {
+            @Override
+            public void bluetoothOff() {
+                long endTime = SystemClock.elapsedRealtime();
+                // should happen basically immediately
+                assertTrue(endTime - startTime <= 50);
+                cdl.countDown();
+            }
+
+            @Override
+            public void bluetoothOn() {
+                fail();
+            }
+
+            @Override
+            public void bluetoothTurningOff() {
+                fail();
+            }
+
+            @Override
+            public void bluetoothTurningOn() {
+                fail();
+            }
+        });
+        // bluetooth on intent
+        Intent i = new Intent(BluetoothAdapter.ACTION_STATE_CHANGED);
+        i.putExtra(BluetoothAdapter.EXTRA_STATE, BluetoothAdapter.STATE_OFF);
+        statusListener.receiver.onReceive(ctx, i);
+        cdl.await(2, TimeUnit.SECONDS);
+        statusListener.removeListener();
+    }
+
+    /**
+     * Test typical case, bluetooth was on when app was started, user turns it off
+     */
+    @Test
+    public void testBluetoothTurningOffToOffCallbackShouldHappenWithNoDelay() throws InterruptedException {
+        // assume BT was off
+        statusListener.setCurrentState(BluetoothAdapter.STATE_ON);
+        final long startTime = SystemClock.elapsedRealtime();
+        CountDownLatch cdl = new CountDownLatch(2);
+        statusListener.setListener(new BluetoothRadioStatusListener.BluetoothOnListener() {
+            @Override
+            public void bluetoothOff() {
+                long endTime = SystemClock.elapsedRealtime();
+                // should happen basically immediately
+                assertTrue(endTime - startTime <= 50);
+                cdl.countDown();
+            }
+
+            @Override
+            public void bluetoothOn() {
+                fail();
+            }
+
+            @Override
+            public void bluetoothTurningOff() {
+                long endTime = SystemClock.elapsedRealtime();
+                // should happen basically immediately
+                assertTrue(endTime - startTime <= 50);
+                cdl.countDown();
+            }
+
+            @Override
+            public void bluetoothTurningOn() {
+                fail();
+            }
+        });
+        // bluetooth on intent
+        Intent i = new Intent(BluetoothAdapter.ACTION_STATE_CHANGED);
+        i.putExtra(BluetoothAdapter.EXTRA_STATE, BluetoothAdapter.STATE_TURNING_OFF);
+        statusListener.receiver.onReceive(ctx, i);
+        i.putExtra(BluetoothAdapter.EXTRA_STATE, BluetoothAdapter.STATE_OFF);
+        statusListener.receiver.onReceive(ctx, i);
+        cdl.await(2, TimeUnit.SECONDS);
+        statusListener.removeListener();
+    }
+
+    /**
+     * Test typical case, bluetooth was on when app was started, user turns it off
+     */
+    @Test
+    public void testBluetoothOffOnOffCallbackShouldHappenAfterDelay() throws InterruptedException {
+        // assume BT was off
+        statusListener.setCurrentState(BluetoothAdapter.STATE_ON);
+        final long startTime = SystemClock.elapsedRealtime();
+        CountDownLatch cdl = new CountDownLatch(1);
+        statusListener.setListener(new BluetoothRadioStatusListener.BluetoothOnListener() {
+            @Override
+            public void bluetoothOff() {
+                long endTime = SystemClock.elapsedRealtime();
+                long diff = endTime - startTime;
+                assertTrue(diff >= BluetoothRadioStatusListener.MIN_TURNING_OFF_CALLBACK_DELAY && diff <= (BluetoothRadioStatusListener.MIN_TURNING_OFF_CALLBACK_DELAY * 2));
+                cdl.countDown();
+            }
+
+            @Override
+            public void bluetoothOn() {
+                fail();
+            }
+
+            @Override
+            public void bluetoothTurningOff() {
+                fail();
+            }
+
+            @Override
+            public void bluetoothTurningOn() {
+                fail();
+            }
+        });
+        // bluetooth on intent
+        Intent i = new Intent(BluetoothAdapter.ACTION_STATE_CHANGED);
+        i.putExtra(BluetoothAdapter.EXTRA_STATE, BluetoothAdapter.STATE_OFF);
+        statusListener.receiver.onReceive(ctx, i);
+        i = new Intent(BluetoothAdapter.ACTION_STATE_CHANGED);
+        i.putExtra(BluetoothAdapter.EXTRA_STATE, BluetoothAdapter.STATE_ON);
+        statusListener.receiver.onReceive(ctx, i);
+        i = new Intent(BluetoothAdapter.ACTION_STATE_CHANGED);
+        i.putExtra(BluetoothAdapter.EXTRA_STATE, BluetoothAdapter.STATE_OFF);
+        statusListener.receiver.onReceive(ctx, i);
+        cdl.await(2, TimeUnit.SECONDS);
+        statusListener.removeListener();
+    }
+
+    /**
+     * Test typical case, bluetooth was on when app was started, user turns it off
+     */
+    @Test
+    public void testBluetoothOnOffOnOffOnCallbackShouldHappenAfterDelay() throws InterruptedException {
+        // assume BT was off
+        statusListener.setCurrentState(BluetoothAdapter.STATE_OFF);
+        final long startTime = SystemClock.elapsedRealtime();
+        CountDownLatch cdl = new CountDownLatch(1);
+        final int[] onCallCount = new int[]{1};
+        statusListener.setListener(new BluetoothRadioStatusListener.BluetoothOnListener() {
+            @Override
+            public void bluetoothOff() {
+                fail();
+            }
+
+            @Override
+            public void bluetoothOn() {
+                long endTime = SystemClock.elapsedRealtime();
+                long diff = endTime - startTime;
+                assertTrue(diff >= BluetoothRadioStatusListener.MIN_TURNING_ON_CALLBACK_DELAY && diff <= (BluetoothRadioStatusListener.MIN_TURNING_ON_CALLBACK_DELAY * 2));
+                onCallCount[0] = onCallCount[0]++;
+                // not entirely sure if this works
+                if(onCallCount[0] > 2) {
+                    fail();
+                } else {
+                    cdl.countDown();
+                }
+            }
+
+            @Override
+            public void bluetoothTurningOff() {
+                fail();
+            }
+
+            @Override
+            public void bluetoothTurningOn() {
+                fail();
+            }
+        });
+        // bluetooth on intent
+        Intent i = new Intent(BluetoothAdapter.ACTION_STATE_CHANGED);
+        i.putExtra(BluetoothAdapter.EXTRA_STATE, BluetoothAdapter.STATE_ON);
+        statusListener.receiver.onReceive(ctx, i);
+        i = new Intent(BluetoothAdapter.ACTION_STATE_CHANGED);
+        i.putExtra(BluetoothAdapter.EXTRA_STATE, BluetoothAdapter.STATE_OFF);
+        statusListener.receiver.onReceive(ctx, i);
+        i = new Intent(BluetoothAdapter.ACTION_STATE_CHANGED);
+        i.putExtra(BluetoothAdapter.EXTRA_STATE, BluetoothAdapter.STATE_ON);
+        statusListener.receiver.onReceive(ctx, i);
+        i = new Intent(BluetoothAdapter.ACTION_STATE_CHANGED);
+        i.putExtra(BluetoothAdapter.EXTRA_STATE, BluetoothAdapter.STATE_OFF);
+        statusListener.receiver.onReceive(ctx, i);
+        i = new Intent(BluetoothAdapter.ACTION_STATE_CHANGED);
+        i.putExtra(BluetoothAdapter.EXTRA_STATE, BluetoothAdapter.STATE_ON);
+        statusListener.receiver.onReceive(ctx, i);
+        cdl.await(2, TimeUnit.SECONDS);
+        statusListener.removeListener();
+    }
+
+    /**
+     * Test typical case, bluetooth was on when app was started, user turns it off
+     */
+    @Test
+    public void testBluetoothOnOffOnOffOnCallbackOnlyDeliveredOnce() throws InterruptedException {
+        // assume BT was off
+        statusListener.setCurrentState(BluetoothAdapter.STATE_OFF);
+        CountDownLatch cdl = new CountDownLatch(1);
+        final int[] onCallCount = new int[]{1};
+        statusListener.setListener(new BluetoothRadioStatusListener.BluetoothOnListener() {
+            @Override
+            public void bluetoothOff() {
+                fail();
+            }
+
+            @Override
+            public void bluetoothOn() {
+                onCallCount[0] = onCallCount[0]++;
+                // not entirely sure if this works
+                if(onCallCount[0] > 2) {
+                    fail();
+                } else {
+                    mockHandler.postDelayed(() -> {
+                        // if we didn't get called back more than once in 500ms success!
+                        assertTrue(true);
+                        cdl.countDown();
+                    }, 500);
+                }
+            }
+
+            @Override
+            public void bluetoothTurningOff() {
+                fail();
+            }
+
+            @Override
+            public void bluetoothTurningOn() {
+                fail();
+            }
+        });
+        // bluetooth on intent
+        Intent i = new Intent(BluetoothAdapter.ACTION_STATE_CHANGED);
+        i.putExtra(BluetoothAdapter.EXTRA_STATE, BluetoothAdapter.STATE_ON);
+        statusListener.receiver.onReceive(ctx, i);
+        i = new Intent(BluetoothAdapter.ACTION_STATE_CHANGED);
+        i.putExtra(BluetoothAdapter.EXTRA_STATE, BluetoothAdapter.STATE_OFF);
+        statusListener.receiver.onReceive(ctx, i);
+        i = new Intent(BluetoothAdapter.ACTION_STATE_CHANGED);
+        i.putExtra(BluetoothAdapter.EXTRA_STATE, BluetoothAdapter.STATE_ON);
+        statusListener.receiver.onReceive(ctx, i);
+        i = new Intent(BluetoothAdapter.ACTION_STATE_CHANGED);
+        i.putExtra(BluetoothAdapter.EXTRA_STATE, BluetoothAdapter.STATE_OFF);
+        statusListener.receiver.onReceive(ctx, i);
+        i = new Intent(BluetoothAdapter.ACTION_STATE_CHANGED);
+        i.putExtra(BluetoothAdapter.EXTRA_STATE, BluetoothAdapter.STATE_ON);
+        statusListener.receiver.onReceive(ctx, i);
+        cdl.await(2, TimeUnit.SECONDS);
+        statusListener.removeListener();
+    }
+
+    /**
+     * Test typical case, bluetooth was on when app was started, user turns it off
+     */
+    @Test
+    public void testBluetoothOffTurningOnOnCallbackShouldHappenAfterDelay() throws InterruptedException {
+        // assume BT was off
+        statusListener.setCurrentState(BluetoothAdapter.STATE_OFF);
+        final long startTime = SystemClock.elapsedRealtime();
+        CountDownLatch cdl = new CountDownLatch(2);
+        statusListener.setListener(new BluetoothRadioStatusListener.BluetoothOnListener() {
+            @Override
+            public void bluetoothOff() {
+                fail();
+            }
+
+            @Override
+            public void bluetoothOn() {
+                long endTime = SystemClock.elapsedRealtime();
+                long diff = endTime - startTime;
+                assertTrue(diff >= BluetoothRadioStatusListener.MIN_TURNING_ON_CALLBACK_DELAY && diff <= (BluetoothRadioStatusListener.MIN_TURNING_ON_CALLBACK_DELAY * 2));
+                cdl.countDown();
+            }
+
+            @Override
+            public void bluetoothTurningOff() {
+                fail();
+            }
+
+            @Override
+            public void bluetoothTurningOn() {
+                long endTime = SystemClock.elapsedRealtime();
+                long diff = endTime - startTime;
+                assertTrue(diff <= 50);
+                cdl.countDown();
+            }
+        });
+        // bluetooth on intent
+        Intent i = new Intent(BluetoothAdapter.ACTION_STATE_CHANGED);
+        i.putExtra(BluetoothAdapter.EXTRA_STATE, BluetoothAdapter.STATE_TURNING_ON);
+        statusListener.receiver.onReceive(ctx, i);
+        i = new Intent(BluetoothAdapter.ACTION_STATE_CHANGED);
+        i.putExtra(BluetoothAdapter.EXTRA_STATE, BluetoothAdapter.STATE_ON);
+        statusListener.receiver.onReceive(ctx, i);
+        cdl.await(2, TimeUnit.SECONDS);
+        statusListener.removeListener();
+    }
+
+    /**
+     * Test typical case, bluetooth was on when app was started, user turns it off
+     */
+    @Test
+    public void testBluetoothOnTurningOffCallbackShouldHappenAfterDelay() throws InterruptedException {
+        // assume BT was off
+        statusListener.setCurrentState(BluetoothAdapter.STATE_ON);
+        final long startTime = SystemClock.elapsedRealtime();
+        CountDownLatch cdl = new CountDownLatch(2);
+        statusListener.setListener(new BluetoothRadioStatusListener.BluetoothOnListener() {
+            @Override
+            public void bluetoothOff() {
+                long endTime = SystemClock.elapsedRealtime();
+                long diff = endTime - startTime;
+                assertTrue(diff >= BluetoothRadioStatusListener.MIN_TURNING_OFF_CALLBACK_DELAY && diff <= (BluetoothRadioStatusListener.MIN_TURNING_OFF_CALLBACK_DELAY * 2));
+                cdl.countDown();
+            }
+
+            @Override
+            public void bluetoothOn() {
+                fail();
+            }
+
+            @Override
+            public void bluetoothTurningOff() {
+                long endTime = SystemClock.elapsedRealtime();
+                long diff = endTime - startTime;
+                assertTrue(diff >= 50);
+                cdl.countDown();
+            }
+
+            @Override
+            public void bluetoothTurningOn() {
+                fail();
+            }
+        });
+        // bluetooth on intent
+        Intent i = new Intent(BluetoothAdapter.ACTION_STATE_CHANGED);
+        i.putExtra(BluetoothAdapter.EXTRA_STATE, BluetoothAdapter.STATE_TURNING_OFF);
+        statusListener.receiver.onReceive(ctx, i);
+        i = new Intent(BluetoothAdapter.ACTION_STATE_CHANGED);
+        i.putExtra(BluetoothAdapter.EXTRA_STATE, BluetoothAdapter.STATE_OFF);
+        statusListener.receiver.onReceive(ctx, i);
+        cdl.await(2, TimeUnit.SECONDS);
+        statusListener.removeListener();
+    }
+}

--- a/src/test/java/com/fitbit/bluetooth/fbgatt/PeripheralScannerTest.java
+++ b/src/test/java/com/fitbit/bluetooth/fbgatt/PeripheralScannerTest.java
@@ -130,6 +130,16 @@ public class PeripheralScannerTest {
             public void onBluetoothOn() {
 
             }
+
+            @Override
+            public void onBluetoothTurningOn() {
+
+            }
+
+            @Override
+            public void onBluetoothTurningOff() {
+
+            }
         };
         FitbitGatt.getInstance().registerGattEventListener(cb);
         FitbitGatt.getInstance().getPeripheralScanner().populateMockScanResultBatchValues(results);
@@ -192,6 +202,16 @@ public class PeripheralScannerTest {
 
             @Override
             public void onBluetoothOn() {
+
+            }
+
+            @Override
+            public void onBluetoothTurningOn() {
+
+            }
+
+            @Override
+            public void onBluetoothTurningOff() {
 
             }
         };
@@ -263,6 +283,16 @@ public class PeripheralScannerTest {
             public void onBluetoothOn() {
 
             }
+
+            @Override
+            public void onBluetoothTurningOn() {
+
+            }
+
+            @Override
+            public void onBluetoothTurningOff() {
+
+            }
         };
         FitbitGatt.getInstance().registerGattEventListener(cb);
         FitbitGatt.getInstance().addScannedDevice(device);
@@ -330,6 +360,16 @@ public class PeripheralScannerTest {
 
             @Override
             public void onBluetoothOn() {
+
+            }
+
+            @Override
+            public void onBluetoothTurningOn() {
+
+            }
+
+            @Override
+            public void onBluetoothTurningOff() {
 
             }
         };
@@ -401,6 +441,16 @@ public class PeripheralScannerTest {
             public void onBluetoothOn() {
 
             }
+
+            @Override
+            public void onBluetoothTurningOn() {
+
+            }
+
+            @Override
+            public void onBluetoothTurningOff() {
+
+            }
         };
         FitbitGatt.getInstance().registerGattEventListener(cb);
         FitbitGatt.getInstance().addScannedDevice(device);
@@ -462,6 +512,16 @@ public class PeripheralScannerTest {
 
             @Override
             public void onBluetoothOn() {
+
+            }
+
+            @Override
+            public void onBluetoothTurningOn() {
+
+            }
+
+            @Override
+            public void onBluetoothTurningOff() {
 
             }
         };


### PR DESCRIPTION
There was a problem where we would deliver gatt server
callbacks on a binder thread, this PR corrects that issue

There were scenarios where a rogue application could toggle bluetooth
aggressively causing multiple on callbacks to be delivered in rapid
succession, this attempts to prevent these issues.