### PR TITLE
Add always connected scanner

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,12 +27,12 @@ def buildNumber = System.getenv("BUILD_NUMBER") != null ? System.getenv("BUILD_N
 def libraryVersionName = sprintf("0.8.0", buildNumber)
 
 android {
-    compileSdkVersion 28
-    buildToolsVersion "28.0.3"
+    compileSdkVersion 29
+    buildToolsVersion "29.0.1"
 
     defaultConfig {
         minSdkVersion 21
-        targetSdkVersion 28
+        targetSdkVersion 29
         versionCode buildNumber
         versionName libraryVersionName
         multiDexEnabled true
@@ -71,13 +71,13 @@ allprojects {
 }
 
 ext {
-    MULTIDEX_VERSION = '1.0.3'
-    APP_COMPAT_VERSION = '28.0.0'
+    MULTIDEX_VERSION = '2.0.1'
+    APP_COMPAT_VERSION = '1.0.2'
     TIMBER_VERSION = '4.7.1'
     JUNIT_VERSION = '4.12'
-    TEST_RUNNER_VERSION = '1.0.2'
+    TEST_RUNNER_VERSION = '1.1.0'
     MOCKITO_VERSION = '2.19.1'
-    STETHO_VERSION = '1.5.0'
+    STETHO_VERSION = '1.5.1'
 }
 
 dependencies {
@@ -85,18 +85,18 @@ dependencies {
     androidTestImplementation("com.android.support.test.espresso:espresso-core:3.0.1", {
         exclude group: 'com.android.support', module: 'support-annotations'
     })
-    implementation "com.android.support:multidex:$MULTIDEX_VERSION"
-    implementation "com.android.support:appcompat-v7:$APP_COMPAT_VERSION"
+    implementation "androidx.multidex:multidex:$MULTIDEX_VERSION"
+    implementation "androidx.appcompat:appcompat:$APP_COMPAT_VERSION"
     implementation "com.jakewharton.timber:timber:$TIMBER_VERSION"
-    debugImplementation "com.facebook.stetho:stetho:$STETHO_VERSION"
+    implementation "com.facebook.stetho:stetho:$STETHO_VERSION"
     testImplementation "junit:junit:$JUNIT_VERSION"
-    testImplementation "com.android.support.test:runner:$TEST_RUNNER_VERSION"
-    testImplementation "com.android.support.test:rules:$TEST_RUNNER_VERSION"
+    testImplementation "androidx.test:runner:$TEST_RUNNER_VERSION"
+    testImplementation "androidx.test:rules:$TEST_RUNNER_VERSION"
     testImplementation "org.mockito:mockito-inline:$MOCKITO_VERSION"
     testImplementation "org.mockito:mockito-core:$MOCKITO_VERSION"
     androidTestImplementation "junit:junit:$JUNIT_VERSION"
-    androidTestImplementation "com.android.support.test:runner:$TEST_RUNNER_VERSION"
-    androidTestImplementation "com.android.support.test:rules:$TEST_RUNNER_VERSION"
+    androidTestImplementation "androidx.test:runner:$TEST_RUNNER_VERSION"
+    androidTestImplementation "androidx.test:rules:$TEST_RUNNER_VERSION"
     androidTestImplementation "org.mockito:mockito-inline:$MOCKITO_VERSION"
     androidTestImplementation "org.mockito:mockito-core:$MOCKITO_VERSION"
     androidTestImplementation("org.mockito:mockito-android:$MOCKITO_VERSION") {
@@ -111,14 +111,39 @@ task sourceJar(type: Jar) {
 
 publishing {
     publications {
-        aar(MavenPublication) {
+        libraryAar(MavenPublication) {
+            groupId packageName
+            version = libraryVersionName
+            artifactId project.getName()
+            artifact sourceJar { classifier 'library' }
+            artifact("$buildDir/outputs/aar/${project.getName()}-library.aar") {classifier 'library' }
+        }
+        releaseAar(MavenPublication) {
+            groupId packageName
             groupId packageName
             version = libraryVersionName
             artifactId project.getName()
 
-            artifact(sourceJar)
-            artifact("$buildDir/outputs/aar/${project.getName()}-library.aar")
+            artifact("$buildDir/outputs/aar/${project.getName()}-release.aar") { classifier 'release' }
+            artifact sourceJar { classifier 'release' }
+        }
+        debugAar(MavenPublication) {
+            groupId packageName
+            groupId packageName
+            version = libraryVersionName
+            artifactId project.getName()
+
+            artifact("$buildDir/outputs/aar/${project.getName()}-debug.aar") { classifier 'debug' }
+            artifact sourceJar { classifier 'debug' }
+        }
+        testAar(MavenPublication) {
+            groupId packageName
+            groupId packageName
+            version = libraryVersionName
+            artifactId project.getName()
+
+            artifact("$buildDir/outputs/aar/${project.getName()}-batteryDataTest.aar") { classifier 'test' }
+            artifact sourceJar { classifier 'test' }
         }
     }
 }
-

--- a/src/androidTest/java/com/fitbit/bluetooth/fbgatt/GattServerTests.java
+++ b/src/androidTest/java/com/fitbit/bluetooth/fbgatt/GattServerTests.java
@@ -22,7 +22,7 @@ import android.bluetooth.BluetoothGattService;
 import android.content.Context;
 import android.os.Handler;
 import android.os.Looper;
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 import android.support.test.InstrumentationRegistry;
 import android.support.test.runner.AndroidJUnit4;
 

--- a/src/androidTest/java/com/fitbit/bluetooth/fbgatt/PeripheralScannerTest.java
+++ b/src/androidTest/java/com/fitbit/bluetooth/fbgatt/PeripheralScannerTest.java
@@ -10,19 +10,16 @@ package com.fitbit.bluetooth.fbgatt;
 
 import android.bluetooth.le.ScanFilter;
 import android.content.Context;
-import android.content.Intent;
 import android.content.IntentFilter;
 import android.os.Handler;
 import android.os.HandlerThread;
 import android.os.Looper;
 import android.os.ParcelUuid;
 import android.os.SystemClock;
-import android.support.annotation.NonNull;
 import android.support.test.InstrumentationRegistry;
 import android.support.test.rule.GrantPermissionRule;
 import android.support.test.runner.AndroidJUnit4;
 
-import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Before;
@@ -38,11 +35,11 @@ import java.util.UUID;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
+import androidx.annotation.NonNull;
 import timber.log.Timber;
 
 import static junit.framework.Assert.assertTrue;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.*;
 
 @RunWith(AndroidJUnit4.class)
 public class PeripheralScannerTest {
@@ -66,7 +63,6 @@ public class PeripheralScannerTest {
         // limit
         SystemClock.sleep(3000);
         FitbitGatt.getInstance().start(appContext);
-        FitbitGatt.getInstance().getPeripheralScanner().setMockMode(false);
         FitbitGatt.getInstance().getPeripheralScanner().setInstrumentationTestMode(true);
         FitbitGatt.getInstance().getPeripheralScanner().cancelScan(this.appContext);
         FitbitGatt.getInstance().getPeripheralScanner().cancelPeriodicalScan(this.appContext);

--- a/src/androidTest/java/com/fitbit/bluetooth/fbgatt/tx/AddGattServerCharacteristicDescriptorTransactionTest.java
+++ b/src/androidTest/java/com/fitbit/bluetooth/fbgatt/tx/AddGattServerCharacteristicDescriptorTransactionTest.java
@@ -19,21 +19,19 @@ import android.bluetooth.BluetoothGattCharacteristic;
 import android.bluetooth.BluetoothGattDescriptor;
 import android.bluetooth.BluetoothGattService;
 import android.content.Context;
-import android.os.Handler;
-import android.os.Looper;
 import android.os.ParcelUuid;
-import android.support.annotation.NonNull;
 import android.support.test.InstrumentationRegistry;
 
 import junit.framework.Assert;
 
-import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
+
+import androidx.annotation.NonNull;
 
 public class AddGattServerCharacteristicDescriptorTransactionTest {
     private static final String MOCK_ADDRESS = "02:00:00:00:00:00";

--- a/src/androidTest/java/com/fitbit/bluetooth/fbgatt/tx/AddGattServerCharacteristicTransactionTest.java
+++ b/src/androidTest/java/com/fitbit/bluetooth/fbgatt/tx/AddGattServerCharacteristicTransactionTest.java
@@ -19,7 +19,7 @@ import android.bluetooth.BluetoothGattCharacteristic;
 import android.bluetooth.BluetoothGattService;
 import android.content.Context;
 import android.os.ParcelUuid;
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 import android.support.test.InstrumentationRegistry;
 
 import junit.framework.Assert;

--- a/src/androidTest/java/com/fitbit/bluetooth/fbgatt/tx/AddGattServerServiceTransactionTest.java
+++ b/src/androidTest/java/com/fitbit/bluetooth/fbgatt/tx/AddGattServerServiceTransactionTest.java
@@ -15,11 +15,9 @@ import com.fitbit.bluetooth.fbgatt.GattState;
 import com.fitbit.bluetooth.fbgatt.GattTransactionCallback;
 import com.fitbit.bluetooth.fbgatt.TransactionResult;
 
-import android.bluetooth.BluetoothGattCharacteristic;
 import android.bluetooth.BluetoothGattService;
 import android.content.Context;
 import android.os.ParcelUuid;
-import android.support.annotation.NonNull;
 import android.support.test.InstrumentationRegistry;
 
 import junit.framework.Assert;
@@ -30,6 +28,8 @@ import org.junit.Test;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
+
+import androidx.annotation.NonNull;
 
 public class AddGattServerServiceTransactionTest {
     private static final String MOCK_ADDRESS = "02:00:00:00:00:00";

--- a/src/androidTest/java/com/fitbit/bluetooth/fbgatt/tx/GattClientRefreshGattTransactionTest.java
+++ b/src/androidTest/java/com/fitbit/bluetooth/fbgatt/tx/GattClientRefreshGattTransactionTest.java
@@ -18,7 +18,7 @@ import com.fitbit.bluetooth.fbgatt.TransactionResult;
 import android.bluetooth.BluetoothGattService;
 import android.content.Context;
 import android.os.ParcelUuid;
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 import android.support.test.InstrumentationRegistry;
 
 import org.junit.After;

--- a/src/batteryDataTest/res/values/values.xml
+++ b/src/batteryDataTest/res/values/values.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright 2019 Fitbit, Inc. All rights reserved.
+  ~
+  ~ This Source Code Form is subject to the terms of the Mozilla Public
+  ~ License, v. 2.0. If a copy of the MPL was not distributed with this
+  ~ file, You can obtain one at https://mozilla.org/MPL/2.0/.
+  -->
+
+<resources>
+</resources>

--- a/src/main/AndroidManifest.xml
+++ b/src/main/AndroidManifest.xml
@@ -7,9 +7,7 @@
   -->
 
 <manifest package="com.fitbit.bluetooth.fbgatt"
-
-          xmlns:android="http://schemas.android.com/apk/res/android"
->
+          xmlns:android="http://schemas.android.com/apk/res/android">
 
     <uses-permission android:name="android.permission.BLUETOOTH"/>
     <uses-permission android:name="android.permission.BLUETOOTH_ADMIN"/>
@@ -24,6 +22,12 @@
             <intent-filter>
                 <!-- if you change this make sure to also change it in {@link PeripheralScanner} -->
                 <action android:name="com.fitbit.bluetooth.fbgatt.ScannedDevice" />
+            </intent-filter>
+        </receiver>
+        <receiver android:name=".LowEnergyAclListener" android:exported="true"
+                  android:permission="android.permission.ACCESS_FINE_LOCATION">
+            <intent-filter>
+                <action android:name="BluetoothDevice.ACTION_FOUND" />
             </intent-filter>
         </receiver>
     </application>

--- a/src/main/java/com/fitbit/bluetooth/fbgatt/AlwaysConnectedScanner.java
+++ b/src/main/java/com/fitbit/bluetooth/fbgatt/AlwaysConnectedScanner.java
@@ -1,0 +1,668 @@
+/*
+ * Copyright 2019 Fitbit, Inc. All rights reserved.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+package com.fitbit.bluetooth.fbgatt;
+
+import com.fitbit.bluetooth.fbgatt.tx.GattClientDiscoverServicesTransaction;
+import com.fitbit.bluetooth.fbgatt.tx.GattConnectTransaction;
+import com.fitbit.bluetooth.fbgatt.tx.GattDisconnectTransaction;
+
+import android.annotation.SuppressLint;
+import android.annotation.TargetApi;
+import android.bluetooth.le.ScanFilter;
+import android.bluetooth.le.ScanRecord;
+import android.bluetooth.le.ScanResult;
+import android.content.Context;
+import android.os.Build;
+import android.os.Handler;
+import android.os.Looper;
+import android.os.PowerManager;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.annotation.VisibleForTesting;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import timber.log.Timber;
+
+/**
+ * This scanner is designed to remain connected to one or more bluetooth peripherals through
+ * bluetooth toggles, etc ...  Changing the filters will internally stop and start the scanner.
+ * <p>
+ * This is a common use-case for wearable peripherals, and for power reasons it is preferred to
+ * remain connected rather than to continuously scan and connect.
+ * <p>
+ * Please see the README.md for more detailed instructions
+ * <p>
+ * Created by iowens on 6/10/19.
+ */
+@SuppressWarnings("unused") // API Method
+public class AlwaysConnectedScanner implements FitbitGatt.FitbitGattCallback {
+    /**
+     * Time between high priority scans
+     */
+    private static final long MIN_TIME_BETWEEN_LOW_LATENCY_SCANS = TimeUnit.MINUTES.toMillis(5);
+    /**
+     * The maximum amount of time allowed for a high-priority scan, there is no reason that any peripheral
+     * should require more than ten seconds of high priority scanning
+     */
+    private static final long MAX_TIME_FOR_HIGH_PRIORITY_SCAN = TimeUnit.SECONDS.toMillis(10);
+    /**
+     * Whether this is test mode or not
+     */
+    private boolean testMode;
+    /**
+     * Whether we should keep looking even after a device connects ( we will know by ACL )
+     */
+    private boolean shouldKeepLooking;
+    /**
+     * How many devices should we be looking for, if less than 1 then this feature is disabled
+     * disabled and the system will keep scanning regardless of shouldKeepLooking
+     */
+    private int numberOfExpectedDevices;
+    /**
+     * The number of devices that we have actually matched and connected
+     */
+    private AtomicInteger numberOfMatchingConnectedDevices = new AtomicInteger(0);
+    /**
+     * The pointer to the peripheral scanner
+     */
+    private @Nullable
+    PeripheralScanner scanner;
+    /**
+     * The scan filters to find the devices we are looking for
+     */
+    private CopyOnWriteArrayList<ScanFilter> scanFilters = new CopyOnWriteArrayList<>();
+    /**
+     * The connected scanner listeners
+     */
+    private CopyOnWriteArrayList<AlwaysConnectedScannerListener> listeners = new CopyOnWriteArrayList<>();
+    /**
+     * Whether the scanner is enabled or not
+     */
+    private AtomicBoolean isScannerEnabled = new AtomicBoolean(false);
+    /**
+     * Will indicate whether a high priority scan can be performed
+     */
+    private AtomicBoolean canStartHighPriorityScan = new AtomicBoolean(true);
+    /**
+     * Member for a main handler for scheduling
+     */
+    private Handler mainHandlerForScheduling;
+    /**
+     * Test mode high priority scan time, shouldn't be used for production purposes
+     */
+    @VisibleForTesting
+    static final long MAX_TIME_FOR_TEST_MODE_HIGH_PRIORITY_SCAN = TimeUnit.SECONDS.toMillis(2);
+
+    /**
+     * Will set the initial expectation for how this scanner should operate when devices are found
+     *
+     * @param numberOfExpectedDevices The number of expected devices
+     * @param shouldKeepLooking       Whether to keep looking after one of the devices is found
+     */
+    @SuppressWarnings("unused") // API Method
+    AlwaysConnectedScanner(int numberOfExpectedDevices, boolean shouldKeepLooking) {
+        this(numberOfExpectedDevices, shouldKeepLooking, false);
+    }
+
+    private AlwaysConnectedScanner(int numberOfExpectedDevices, boolean shouldKeepLooking, boolean testMode) {
+        this.numberOfExpectedDevices = numberOfExpectedDevices;
+        this.shouldKeepLooking = shouldKeepLooking;
+        this.testMode = testMode;
+        mainHandlerForScheduling = new Handler(Looper.getMainLooper());
+    }
+
+    @VisibleForTesting
+    void setHandler(Handler hand) {
+        mainHandlerForScheduling = hand;
+    }
+
+    /**
+     * We need to be able to do this for testing
+     */
+    @VisibleForTesting
+    void restartCanStart(){
+        canStartHighPriorityScan.set(true);
+    }
+
+    /**
+     * Will register a listener for always connected events if not already registered, if the instance
+     * is already registered, then it will be ignored
+     *
+     * @param listener The always connected scanner listener for callbacks
+     */
+    @SuppressWarnings("unused") // API Method
+    public void registerAlwaysConnectedScannerListener(AlwaysConnectedScannerListener listener) {
+        if (!listeners.contains(listener)) {
+            listeners.add(listener);
+        }
+    }
+
+    /**
+     * Will unregister an always connected listener
+     *
+     * @param listener The always connected scanner listener for callbacks
+     */
+    @SuppressWarnings("unused") // API Method
+    public void unregisterAlwaysConnectedScannerListener(AlwaysConnectedScannerListener listener) {
+        listeners.remove(listener);
+    }
+
+    /**
+     * Will fetch the number of expected devices
+     *
+     * @return the number of expected devices
+     */
+    @SuppressWarnings("unused") // API Method
+    public int getNumberOfExpectedDevices() {
+        return numberOfExpectedDevices;
+    }
+
+    /**
+     * Will establish whether this scanner should keep looking for matches
+     *
+     * @return whether to keep looking once a single matching device is connected
+     */
+    @SuppressWarnings("unused") // API Method
+    public boolean shouldKeepLooking() {
+        return shouldKeepLooking;
+    }
+
+    /**
+     * Will set whether the scanner should keep looking when device is connected
+     *
+     * @param shouldKeepLooking true if the scanner should
+     */
+    @SuppressWarnings("unused") // API Method
+    public void setShouldKeepLooking(boolean shouldKeepLooking) {
+        this.shouldKeepLooking = shouldKeepLooking;
+    }
+
+    /**
+     * Will return the state of this scanner, as to whether it is in operation or not
+     *
+     * @return true if this scanner is enabled, false if it is not
+     */
+    @SuppressWarnings("unused") // API Method
+    public boolean isAlwaysConnectedScannerEnabled() {
+        return isScannerEnabled.get();
+    }
+
+    /**
+     * Will set the number of expected devices, will be picked up once the next set of scans begin
+     *
+     * @param numberOfExpectedDevices The number of expected devices
+     */
+    @SuppressWarnings("unused") // API Method
+    public void setNumberOfExpectedDevices(int numberOfExpectedDevices) {
+        this.numberOfExpectedDevices = numberOfExpectedDevices;
+    }
+
+    /**
+     * Will indicate whether the always connected scanner is in the test mode or not
+     *
+     * @return true if in test mode, false if not
+     */
+    @SuppressWarnings("unused")
+    // API Method
+    boolean isInTestMode() {
+        return testMode;
+    }
+
+    /**
+     * Will add all provided scan filters, intended to only be used internally
+     *
+     * @param filters The list of filters to be added
+     */
+    void setScanFilters(List<ScanFilter> filters) {
+        this.scanFilters.addAll(filters);
+    }
+
+    /**
+     * Will set the system up in test mode
+     *
+     * @param testMode true for test mode, false if not
+     */
+    void setTestMode(boolean testMode) {
+        this.testMode = testMode;
+    }
+
+    /**
+     * Start the scanner with filters
+     *
+     * @param context The android context
+     * @param filters The scan filters to use
+     * @return True if started successfully
+     */
+    @SuppressWarnings("unused") // API Method
+    public boolean startWithFilters(@NonNull Context context, @NonNull List<ScanFilter> filters) {
+        scanFilters.addAll(filters);
+        return start(context);
+    }
+
+    /**
+     * Will add a list of filters to the existing set of filters, will not check for duplicates
+     * and will not clear the existing filter set.  This method will only change the current set of
+     * filters once every 30s so if you call this method multiple times, the changes will be spread
+     * over 30s x n calls.
+     * @param context The android context
+     * @param filters The list of filters
+     */
+    public synchronized void addScanFilters(@NonNull Context context, @NonNull List<ScanFilter> filters) {
+        scanFilters.addAll(filters);
+        if (FitbitGatt.getInstance().getPeripheralScanner() != null) {
+            FitbitGatt.getInstance().getPeripheralScanner().setScanFilters(scanFilters);
+        }
+        // let's only change this once per scan too much warn interval
+        mainHandlerForScheduling.postDelayed(() -> {
+            FitbitGatt.getInstance().getPeripheralScanner().cancelPendingIntentBasedBackgroundScan();
+            FitbitGatt.getInstance().getPeripheralScanner().startPendingIntentBasedBackgroundScan(scanFilters, context);
+        }, PeripheralScanner.SCAN_TOO_MUCH_WARN_INTERVAL);
+    }
+
+    /**
+     * Will append a new scan filter to the set of scan filters, will restart the internal
+     * background scanner to ensure that the new filter is picked up.  Since we want to always
+     * avoid the scan-too-much no-op for our scanner, we will only change this once per 30s.
+     *
+     * This method will only change the current set of
+     * filters once every 30s so if you call this method multiple times, the changes will be spread
+     * over 30s x n calls.
+     * @param context The android context
+     * @param scanFilter The new scan filter to add
+     */
+
+    public synchronized void addScanFilter(@NonNull Context context, @NonNull ScanFilter scanFilter) {
+        if (!scanFilters.contains(scanFilter)) {
+            scanFilters.add(scanFilter);
+        }
+        if (FitbitGatt.getInstance().getPeripheralScanner() != null) {
+            FitbitGatt.getInstance().getPeripheralScanner().setScanFilters(scanFilters);
+        }
+        // let's only change this once per scan too much warn interval
+        mainHandlerForScheduling.postDelayed(() -> {
+            FitbitGatt.getInstance().getPeripheralScanner().cancelPendingIntentBasedBackgroundScan();
+            FitbitGatt.getInstance().getPeripheralScanner().startPendingIntentBasedBackgroundScan(scanFilters, context);
+        }, PeripheralScanner.SCAN_TOO_MUCH_WARN_INTERVAL);
+    }
+
+    /**
+     * Will remove a scan filter from the set of scan filters.
+     *
+     * This method will only change the current set of
+     * filters once every 30s so if you call this method multiple times, the changes will be spread
+     * over 30s x n calls.
+     * @param context The android context
+     * @param scanFilter The scan filter to remove
+     */
+
+    public synchronized void removeScanFilter(@NonNull Context context, @NonNull ScanFilter scanFilter) {
+        if (!scanFilters.contains(scanFilter)) {
+            scanFilters.remove(scanFilter);
+        }
+        if (FitbitGatt.getInstance().getPeripheralScanner() != null) {
+            FitbitGatt.getInstance().getPeripheralScanner().setScanFilters(scanFilters);
+        }
+        // let's only change this once per scan too much warn interval
+        mainHandlerForScheduling.postDelayed(() -> {
+            FitbitGatt.getInstance().getPeripheralScanner().cancelPendingIntentBasedBackgroundScan();
+            FitbitGatt.getInstance().getPeripheralScanner().startPendingIntentBasedBackgroundScan(scanFilters, context);
+        }, PeripheralScanner.SCAN_TOO_MUCH_WARN_INTERVAL);
+    }
+
+    /**
+     * Will start finding and connecting to devices that match the filters.  Will not deal with matching
+     * presently connected devices at the time of the start call.
+     *
+     * @param context The android application context
+     * @return true if the scanner can start searching, false if the raw scanner is in use or the filters are insufficient
+     */
+
+    public boolean start(@NonNull Context context) {
+        scanner = FitbitGatt.getInstance().getPeripheralScanner();
+        if (scanner == null) {
+            Timber.w("The scanner isn't set up yet, did you call FitbitGatt#start(...)?");
+            return false;
+        }
+        if (scanner.isScanning() || scanner.isPeriodicalScanEnabled() || scanner.isPendingIntentScanning()) {
+            Timber.w("You can not start an always connected scanner while using the regular scanner");
+            return false;
+        }
+        if (scanFilters.isEmpty()) {
+            Timber.w("You can not start a scanner with no filters");
+            return false;
+        }
+        if(isScannerEnabled.get()) {
+            Timber.w("The scanner was already enabled, no need to call this again");
+            return false;
+        }
+        FitbitGatt.getInstance().registerGattEventListener(this);
+        return startBackgroundScanning(context);
+    }
+
+    private boolean startBackgroundScanning(@NonNull Context context) {
+        // we only want to start a pending intent scan if this is > Oreo MR1
+        // otherwise we'll use the pending intent scan
+        PeripheralScanner peripheralScanner = FitbitGatt.getInstance().getPeripheralScanner();
+        if (peripheralScanner == null) {
+            Timber.w("The scanner isn't set up yet, did you call FitbitGatt#start(...)?");
+            return false;
+        }
+        if (FitbitGatt.atLeastSDK(Build.VERSION_CODES.O_MR1)) {
+            peripheralScanner.startPendingIntentBasedBackgroundScan(scanFilters, context);
+        } else {
+            // this will start a low intensity scan immediately
+            boolean didStart = peripheralScanner.startPeriodicScan(context);
+            if (!didStart) {
+                isScannerEnabled.set(false);
+                return false;
+            }
+        }
+        isScannerEnabled.set(true);
+        return true;
+    }
+
+    private void stopScanningUntilDisconnectionEvent(Context context) {
+        if (isAlwaysConnectedScannerEnabled()) {
+            PeripheralScanner peripheralScanner = FitbitGatt.getInstance().getPeripheralScanner();
+            if (peripheralScanner != null) {
+                boolean didStart = false;
+                if (FitbitGatt.atLeastSDK(Build.VERSION_CODES.O_MR1)) {
+                    peripheralScanner.cancelPendingIntentBasedBackgroundScan();
+                } else {
+                    peripheralScanner.cancelPeriodicalScan(context);
+                }
+                peripheralScanner.cancelHighPriorityScan(context);
+                peripheralScanner.cancelScan(context);
+                Timber.v("Stopped all of the scanning");
+            } else {
+                Timber.w("The scanner isn't set up yet, did you call FitbitGatt#start(...)?");
+            }
+        } else {
+            Timber.w("The scanner was disabled so we will not continue");
+        }
+    }
+
+    private boolean continueBackgroundScanning(@NonNull Context context) {
+        if (isAlwaysConnectedScannerEnabled()) {
+            PeripheralScanner peripheralScanner = FitbitGatt.getInstance().getPeripheralScanner();
+            if (peripheralScanner != null) {
+                boolean didStart = false;
+                if (FitbitGatt.atLeastSDK(Build.VERSION_CODES.O_MR1)) {
+                    return peripheralScanner.startPendingIntentBasedBackgroundScan(scanFilters, context);
+                } else {
+                    return peripheralScanner.startPeriodicScan(context);
+                }
+            } else {
+                Timber.w("The scanner isn't set up yet, did you call FitbitGatt#start(...)?");
+                return false;
+            }
+        } else {
+            Timber.w("The scanner was disabled so we will not continue");
+            return false;
+        }
+    }
+
+    /**
+     * This should be performed due to some user interaction that requires as near a real-time
+     * interaction with the peripheral as possible, can only be performed when the screen is on
+     * and only once every 5 minutes.
+     *
+     * @return false if high priority scan was not started
+     */
+    @SuppressWarnings({"unused", "WeakerAccess"}) // API Method
+    public boolean startHighPriorityScan(@NonNull Context context) {
+        if (!canStartHighPriorityScan.get()) {
+            Timber.w("You can't start a high priority scan right now");
+            return false;
+        }
+        if (testMode) {
+            return startScanIfPossible(context);
+        } else {
+            PowerManager pm = (PowerManager) context.getSystemService(Context.POWER_SERVICE);
+            if (pm == null) {
+                Timber.i("The power manager was null");
+                return false;
+            }
+            if(pm.isInteractive()) {
+                return startScanIfPossible(context);
+            } else {
+                Timber.d("The screen isn't on, can't perform a high priority scan");
+                return false;
+            }
+        }
+    }
+
+    private boolean startScanIfPossible(@NonNull Context context){
+        PeripheralScanner peripheralScanner = FitbitGatt.getInstance().getPeripheralScanner();
+        if(peripheralScanner == null) {
+            Timber.w("The scanner isn't set up yet, did you call FitbitGatt#start(...)?");
+            return false;
+        }
+        boolean didStart = peripheralScanner.startHighPriorityScan(context);
+        if (!didStart) {
+            Timber.w("Couldn't start a high priority scan");
+            return false;
+        }
+        if (testMode) {
+            mainHandlerForScheduling.postDelayed(() -> peripheralScanner.cancelHighPriorityScan(context), MAX_TIME_FOR_TEST_MODE_HIGH_PRIORITY_SCAN);
+        } else {
+            mainHandlerForScheduling.postDelayed(() -> peripheralScanner.cancelHighPriorityScan(context), MAX_TIME_FOR_HIGH_PRIORITY_SCAN);
+        }
+        Timber.v("Will start high priority scanning, but will cancel in %dms", MAX_TIME_FOR_HIGH_PRIORITY_SCAN);
+        mainHandlerForScheduling.postDelayed(() -> canStartHighPriorityScan.set(true), MIN_TIME_BETWEEN_LOW_LATENCY_SCANS);
+        canStartHighPriorityScan.set(false);
+        return true;
+    }
+
+    /**
+     * Will stop the operation of this scanner
+     */
+
+    public void stop(@NonNull Context context) {
+        // will stop the always connected scanner
+        FitbitGatt.getInstance().unregisterGattEventListener(this);
+        PeripheralScanner peripheralScanner = FitbitGatt.getInstance().getPeripheralScanner();
+        if (peripheralScanner != null) {
+            peripheralScanner.cancelScan(context);
+            peripheralScanner.cancelPendingIntentBasedBackgroundScan();
+            peripheralScanner.cancelPeriodicalScan(context);
+        } else {
+            Timber.w("The scanner isn't set up yet, did you call FitbitGatt#start(...)?");
+            return;
+        }
+        isScannerEnabled.set(false);
+    }
+
+    /* ---------------------------------- General GATT callbacks ------------------------------ */
+
+    @SuppressLint("VisibleForTests")
+    @Override
+    public void onBluetoothPeripheralDiscovered(GattConnection connection) {
+        // we've discovered a device that is matching, let's try to connect
+        Context appContext = FitbitGatt.getInstance().getAppContext();
+        if (appContext != null) {
+            // well, we will try to connect and evaluate the device against our filters.  If it
+            // matches, then we will leave it connected, otherwise we will release the client_if
+            // if we are in mock mode, we should finish the connection mock
+            if (testMode) {
+                connection.setMockMode(true);
+                connection.setState(GattState.CONNECTED);
+                int matchedDevices = numberOfMatchingConnectedDevices.incrementAndGet();
+                // if the number of expected matched devices has been hit and continue scanning is
+                // not enabled, then the scans will be cancelled until the connected devices
+                // drops below the expected number
+                if (numberOfExpectedDevices > 0 && !shouldKeepLooking && matchedDevices >= numberOfExpectedDevices) {
+                    stopScanningUntilDisconnectionEvent(appContext);
+                }
+                Timber.v("Connection %s matches, calling listeners", connection);
+                for (AlwaysConnectedScannerListener listener : listeners) {
+                    listener.onPeripheralConnected(connection);
+                }
+                Timber.v("Matched devices connected: %d", matchedDevices);
+            } else {
+                GattConnectTransaction tx = new GattConnectTransaction(connection, GattState.CONNECTED);
+                connection.runTx(tx, result -> {
+                    if (result.getResultStatus().equals(TransactionResult.TransactionResultStatus.SUCCESS)) {
+                        Timber.v("Connected, now discovering");
+                        // we will go ahead and discover, since we are going through the hassle of connecting
+                        // it doesn't make sense to hand the caller a connection that isn't immediately usable
+                        // shouldn't be a big deal if already discovered, will return from cache
+                        GattClientDiscoverServicesTransaction discover = new GattClientDiscoverServicesTransaction(connection, GattState.DISCOVERY_SUCCESS);
+                        connection.runTx(discover, result1 -> {
+                            if (result1.getResultStatus().equals(TransactionResult.TransactionResultStatus.SUCCESS)) {
+                                // let's match it against filters, this could be expensive, so let's do it on the
+                                // connection thread
+                                connection.getClientTransactionQueueController().queueTransaction(() -> {
+                                    for (ScanFilter filter : scanFilters) {
+                                        if (doesConnectionMatchFilter(connection, filter)) {
+                                            int matchedDevices = numberOfMatchingConnectedDevices.incrementAndGet();
+                                            // if the number of expected matched devices has been hit and continue scanning is
+                                            // not enabled, then the scans will be cancelled until the connected devices
+                                            // drops below the expected number
+                                            if (numberOfExpectedDevices > 0 && !shouldKeepLooking && matchedDevices >= numberOfExpectedDevices) {
+                                                stopScanningUntilDisconnectionEvent(appContext);
+                                            }
+                                            Timber.v("Connection %s matches, calling listeners", connection);
+                                            for (AlwaysConnectedScannerListener listener : listeners) {
+                                                listener.onPeripheralConnected(connection);
+                                            }
+                                            Timber.v("Matched devices connected: %d", matchedDevices);
+                                            return;
+                                        }
+                                    }
+                                    // if there is no match, we can remain silent about it
+                                    GattDisconnectTransaction disconnect = new GattDisconnectTransaction(connection, GattState.DISCONNECTED);
+                                    connection.runTx(disconnect, result11 -> Timber.v("No match, tried to disconnect with result : %s", result11));
+                                });
+                            }
+                        });
+                    } else {
+                        for (AlwaysConnectedScannerListener listener : listeners) {
+                            listener.onPeripheralConnectionError(result);
+                        }
+                    }
+                });
+            }
+        }
+    }
+
+    @Override
+    public void onBluetoothPeripheralDisconnected(GattConnection connection) {
+        // realistically we don't need to do anything here except decrement matching devices
+        connection.getClientTransactionQueueController().queueTransaction(() -> {
+            for (ScanFilter filter : scanFilters) {
+                if (doesConnectionMatchFilter(connection, filter)) {
+                    int matchedDevices = numberOfMatchingConnectedDevices.get();
+                    if (matchedDevices > 0) {
+                        matchedDevices = numberOfMatchingConnectedDevices.decrementAndGet();
+                        Timber.v("Matched devices decremented to: %d", matchedDevices);
+                    }
+                }
+            }
+            // if something disconnected and we are configured to continue to match, we will
+            // continue scanning, if we are already scanning this will do nothing.
+            int matchingDevices = numberOfMatchingConnectedDevices.get();
+            if (numberOfExpectedDevices > 1 && matchingDevices < numberOfExpectedDevices) {
+                Timber.v("Dropped below the number of expected devices, so we should start scanning again");
+                if (FitbitGatt.getInstance().getAppContext() != null) {
+                    boolean didStart = continueBackgroundScanning(FitbitGatt.getInstance().getAppContext());
+                    if (!didStart) {
+                        Timber.w("Always connected scanner tried to start scanning but failed");
+                    }
+                }
+            }
+        });
+    }
+
+    @Override
+    public void onFitbitGattReady() {
+
+    }
+
+    @Override
+    public void onScanStarted() {
+        // that's cool
+    }
+
+    @Override
+    public void onScanStopped() {
+        Timber.i("Always connected scanner scan stopped");
+    }
+
+    @Override
+    public void onPendingIntentScanStopped() {
+        // bluetooth on means that we should restart our pending intent scan if it is not already
+        // in operation
+        if (FitbitGatt.getInstance().getAppContext() != null) {
+            startBackgroundScanning(FitbitGatt.getInstance().getAppContext());
+        } else {
+            Timber.w("Couldn't resume scans because context is null");
+        }
+    }
+
+    @Override
+    public void onPendingIntentScanStarted() {
+        // that's cool too
+    }
+
+    @Override
+    public void onBluetoothOff() {
+        // bluetooth off will stop all scans, but will not reset the 30s scan count
+        numberOfMatchingConnectedDevices.set(0);
+        isScannerEnabled.set(false);
+        canStartHighPriorityScan.set(true);
+    }
+
+    @Override
+    public void onBluetoothOn() {
+        // bluetooth on means that we should restart our pending intent scan if it is not already
+        // in operation
+        Timber.i("If BT is coming on you can assume that all of your scan state has been stopped");
+    }
+
+    @Override
+    public void onBluetoothTurningOn() {
+
+    }
+
+    @Override
+    public void onBluetoothTurningOff() {
+
+    }
+
+    /**
+     * Will determine if the cached scan result matches the provided scan filter
+     *
+     * @param connection The gatt connection
+     * @param filter     The scan filter
+     * @return true if it's a match, false if not
+     */
+    @TargetApi(26)
+    private boolean doesConnectionMatchFilter(@NonNull GattConnection connection, ScanFilter filter) {
+        ScanRecord record = connection.getDevice().getScanRecord();
+        if (record == null) {
+            return false;
+        }
+        ScanResult result;
+        if (FitbitGatt.atLeastSDK(Build.VERSION_CODES.O)) {
+            result = new ScanResult(connection.getDevice().device,
+                0x00, 1, 0x00, 0xFF, 127,
+                connection.getDevice().getRssi(), record.getTxPowerLevel(), record, 0);
+        } else {
+            result = new ScanResult(connection.getDevice().device, record, connection.getDevice().getRssi(),
+                0);
+        }
+        return filter.matches(result);
+    }
+}

--- a/src/main/java/com/fitbit/bluetooth/fbgatt/AlwaysConnectedScannerListener.java
+++ b/src/main/java/com/fitbit/bluetooth/fbgatt/AlwaysConnectedScannerListener.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2019 Fitbit, Inc. All rights reserved.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+package com.fitbit.bluetooth.fbgatt;
+
+/**
+ * Will notify listeners of devices that are newly connected so that they can continue to discover
+ * services, etc ... this listener will not notify about disconnections, because the scanner is
+ * supposed to keep the device connected, therefore there is nothing to do if the device disconnects
+ * but wait until it's connected again
+ *
+ * Created by iowens on 6/10/19.
+ */
+
+public interface AlwaysConnectedScannerListener {
+    /**
+     * Will be called back when the device connects
+     *
+     * @param connection the newly connected peripheral's connection object
+     */
+    void onPeripheralConnected(GattConnection connection);
+
+    /**
+     * The transaction result failure of the connection
+     * @param result
+     */
+    void onPeripheralConnectionError(TransactionResult result);
+}

--- a/src/main/java/com/fitbit/bluetooth/fbgatt/AndroidDevice.java
+++ b/src/main/java/com/fitbit/bluetooth/fbgatt/AndroidDevice.java
@@ -8,11 +8,9 @@
 
 package com.fitbit.bluetooth.fbgatt;
 
-import android.support.annotation.Nullable;
+import androidx.annotation.Nullable;
 
 import java.util.HashMap;
-
-import timber.log.Timber;
 
 /**
  * An android device, which is an encapsulation of the build variables in a simple comparable

--- a/src/main/java/com/fitbit/bluetooth/fbgatt/BatteryDataStatsAggregator.java
+++ b/src/main/java/com/fitbit/bluetooth/fbgatt/BatteryDataStatsAggregator.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2019 Fitbit, Inc. All rights reserved.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+package com.fitbit.bluetooth.fbgatt;
+
+import android.annotation.TargetApi;
+import android.content.Context;
+import android.os.Build;
+import android.os.Handler;
+import android.os.Looper;
+import android.os.health.HealthStats;
+import android.os.health.SystemHealthManager;
+import android.os.health.UidHealthStats;
+
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+
+import androidx.annotation.Nullable;
+import timber.log.Timber;
+
+/**
+ * This class is designed to collect performance stats when running the performanceTest variant.
+ * Performance stats in this case are realistically around battery and time consumption for different
+ * areas of BTLE operation
+ *
+ * Created by iowens on 2019-07-09
+ */
+
+class BatteryDataStatsAggregator {
+    private static final long SNAPSHOT_INTERVAL = TimeUnit.SECONDS.toMillis(10);
+    private static final String TAG = "BATTERY";
+    private @Nullable
+    Handler mainHandler;
+    private AtomicLong btTxBytes = new AtomicLong(0);
+    private AtomicLong btRxBytes = new AtomicLong(0);
+    private AtomicLong bluetoothPowerMilliampMilliseconds = new AtomicLong(0);
+    private @Nullable
+    SystemHealthManager healthManager;
+
+    @TargetApi(Build.VERSION_CODES.N)
+    BatteryDataStatsAggregator(@Nullable Context context){
+        if(context != null && BuildConfig.BUILD_TYPE.equals("batteryDataTest") && FitbitGatt.atLeastSDK(Build.VERSION_CODES.N)) {
+            healthManager = (SystemHealthManager) context.getSystemService(Context.SYSTEM_HEALTH_SERVICE);
+            mainHandler = new Handler(Looper.getMainLooper());
+            mainHandler.postDelayed(this::snapshotAndLogMetrics, SNAPSHOT_INTERVAL);
+        }
+    }
+
+    @TargetApi(Build.VERSION_CODES.N)
+    @SuppressWarnings("CatchGeneralException")
+    // because takeMyUidSnapshot wraps RemoteException in a RuntimeException
+    private void snapshotAndLogMetrics(){
+        if(healthManager == null || mainHandler == null || !FitbitGatt.atLeastSDK(Build.VERSION_CODES.N)) {
+            Timber.v("Heath logging not enabled.");
+            return;
+        }
+        HealthStats currentStats = null;
+        try {
+            currentStats = healthManager.takeMyUidSnapshot();
+        } catch(RuntimeException e) {
+            Timber.tag(TAG).e(e, "Couldn't snapshot");
+        }
+        if(currentStats == null) {
+            Timber.tag(TAG).w("Couldn't log snapshot");
+            return;
+        }
+        long oldTxBytes = btTxBytes.getAndSet(currentStats.getMeasurement(UidHealthStats.MEASUREMENT_BLUETOOTH_TX_BYTES));
+        long oldRxBytes = btRxBytes.getAndSet(currentStats.getMeasurement(UidHealthStats.MEASUREMENT_BLUETOOTH_RX_BYTES));
+        long oldMamsValue = bluetoothPowerMilliampMilliseconds.getAndAdd(currentStats.getMeasurement(UidHealthStats.MEASUREMENT_BLUETOOTH_POWER_MAMS));
+        float oldMah = ((((float)oldMamsValue / 1000) * 60) * 60);
+        float newMah = ((((float)bluetoothPowerMilliampMilliseconds.get() / 1000) * 60) * 60);
+        mainHandler.postDelayed(this::snapshotAndLogMetrics, SNAPSHOT_INTERVAL);
+        Timber
+            .tag(TAG)
+            .i("Old BTLE TX: %d, new BTLE TX: %d. Old BTLE RX: %d, new BTLE RX: %d. Old BTLE mAh: %f, new BTLE mAh: %f",
+                oldTxBytes, btTxBytes.get(), oldRxBytes, btRxBytes.get(), oldMah, newMah);
+    }
+
+}

--- a/src/main/java/com/fitbit/bluetooth/fbgatt/BitgattLeScanner.java
+++ b/src/main/java/com/fitbit/bluetooth/fbgatt/BitgattLeScanner.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright 2019 Fitbit, Inc. All rights reserved.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+package com.fitbit.bluetooth.fbgatt;
+
+import com.fitbit.bluetooth.fbgatt.util.GattUtils;
+
+import android.annotation.TargetApi;
+import android.app.PendingIntent;
+import android.bluetooth.BluetoothAdapter;
+import android.bluetooth.le.BluetoothLeScanner;
+import android.bluetooth.le.ScanCallback;
+import android.bluetooth.le.ScanFilter;
+import android.bluetooth.le.ScanSettings;
+import android.content.Context;
+import android.os.Build;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import java.util.List;
+
+import timber.log.Timber;
+
+/**
+ * Concrete implementation of the Android scanner
+ *
+ * Created by iowens on 07/08/19.
+ */
+
+class BitgattLeScanner implements ScannerInterface {
+
+    private final @Nullable BluetoothAdapter adapter;
+    private final @Nullable BluetoothLeScanner leScanner;
+
+    /**
+     * Provides a context for use with manipulating the adapter
+     * @param context The android context
+     */
+    BitgattLeScanner(@Nullable Context context) {
+        if(context != null) {
+            GattUtils utils = new GattUtils();
+            this.adapter = utils.getBluetoothAdapter(context);
+            if(adapter != null) {
+                leScanner = adapter.getBluetoothLeScanner();
+            } else {
+                leScanner = null;
+                Timber.w("The adapter was null");
+            }
+        } else {
+            this.adapter = null;
+            this.leScanner = null;
+            Timber.w("The context was null");
+        }
+    }
+
+    @Override
+    public void startScan(ScanCallback callback) {
+        if(leScanner == null) {
+            Timber.w("The scanner was null, context or adapter was null");
+            return;
+        }
+        leScanner.startScan(callback);
+    }
+
+    @Override
+    public void startScan(List<ScanFilter> filters, ScanSettings settings, ScanCallback callback) {
+        if(leScanner == null) {
+            Timber.w("The scanner was null, context or adapter was null");
+            return;
+        }
+        leScanner.startScan(filters, settings, callback);
+    }
+
+    @TargetApi(Build.VERSION_CODES.O)
+    @Override
+    public int startScan(@Nullable List<ScanFilter> filters, @Nullable ScanSettings settings, @NonNull PendingIntent callbackIntent) {
+        if(leScanner == null || !FitbitGatt.atLeastSDK(Build.VERSION_CODES.O)) {
+            Timber.w("The scanner was null, context or adapter was null");
+            return ScanCallback.SCAN_FAILED_INTERNAL_ERROR;
+        }
+        return leScanner.startScan(filters, settings, callbackIntent);
+    }
+
+    @Override
+    public void stopScan(ScanCallback callback) {
+        if(leScanner == null) {
+            Timber.w("The scanner was null, context or adapter was null");
+            return;
+        }
+        leScanner.stopScan(callback);
+    }
+
+    @TargetApi(Build.VERSION_CODES.O)
+    @Override
+    public void stopScan(PendingIntent callbackIntent) {
+        if(leScanner == null || !FitbitGatt.atLeastSDK(Build.VERSION_CODES.O)) {
+            Timber.w("The scanner was null, the context or adapter must have been null");
+            return;
+        }
+        leScanner.stopScan(callbackIntent);
+    }
+
+    @Override
+    public void flushPendingScanResults(ScanCallback callback) {
+        if(leScanner == null) {
+            Timber.w("The scanner was null, the context or adpater also must have been null");
+            return;
+        }
+        leScanner.flushPendingScanResults(callback);
+    }
+
+    @Override
+    public boolean isBluetoothEnabled() {
+        if(leScanner == null) {
+            return false;
+        } else {
+            if(adapter != null) {
+                return adapter.isEnabled();
+            } else {
+                return false;
+            }
+        }
+    }
+
+    @Override
+    public void cleanup() {
+        // no implementation in concrete class
+    }
+}

--- a/src/main/java/com/fitbit/bluetooth/fbgatt/BluetoothRadioStatusListener.java
+++ b/src/main/java/com/fitbit/bluetooth/fbgatt/BluetoothRadioStatusListener.java
@@ -18,7 +18,7 @@ import android.content.IntentFilter;
 import android.os.Handler;
 import android.os.Looper;
 import android.os.SystemClock;
-import android.support.annotation.VisibleForTesting;
+import androidx.annotation.VisibleForTesting;
 
 import timber.log.Timber;
 

--- a/src/main/java/com/fitbit/bluetooth/fbgatt/CompositeClientTransaction.java
+++ b/src/main/java/com/fitbit/bluetooth/fbgatt/CompositeClientTransaction.java
@@ -8,8 +8,8 @@
 
 package com.fitbit.bluetooth.fbgatt;
 
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/src/main/java/com/fitbit/bluetooth/fbgatt/CompositeServerTransaction.java
+++ b/src/main/java/com/fitbit/bluetooth/fbgatt/CompositeServerTransaction.java
@@ -8,8 +8,8 @@
 
 package com.fitbit.bluetooth.fbgatt;
 
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/src/main/java/com/fitbit/bluetooth/fbgatt/ConnectionEventListener.java
+++ b/src/main/java/com/fitbit/bluetooth/fbgatt/ConnectionEventListener.java
@@ -8,7 +8,7 @@
 
 package com.fitbit.bluetooth.fbgatt;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 /**
  * Will allow a connection user to establish a listener for asynchronous events

--- a/src/main/java/com/fitbit/bluetooth/fbgatt/FitbitBluetoothDevice.java
+++ b/src/main/java/com/fitbit/bluetooth/fbgatt/FitbitBluetoothDevice.java
@@ -13,9 +13,9 @@ import com.fitbit.bluetooth.fbgatt.util.GattUtils;
 
 import android.bluetooth.BluetoothDevice;
 import android.bluetooth.le.ScanRecord;
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
-import android.support.annotation.VisibleForTesting;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.annotation.VisibleForTesting;
 
 import java.util.Locale;
 import java.util.concurrent.CopyOnWriteArrayList;

--- a/src/main/java/com/fitbit/bluetooth/fbgatt/GattClientCallback.java
+++ b/src/main/java/com/fitbit/bluetooth/fbgatt/GattClientCallback.java
@@ -18,7 +18,7 @@ import android.os.Build;
 import android.os.Handler;
 import android.os.HandlerThread;
 import android.os.Looper;
-import android.support.annotation.Nullable;
+import androidx.annotation.Nullable;
 
 import com.fitbit.bluetooth.fbgatt.btcopies.BluetoothGattCharacteristicCopy;
 import com.fitbit.bluetooth.fbgatt.tx.GattClientDiscoverServicesTransaction;

--- a/src/main/java/com/fitbit/bluetooth/fbgatt/GattClientListener.java
+++ b/src/main/java/com/fitbit/bluetooth/fbgatt/GattClientListener.java
@@ -14,7 +14,7 @@ import com.fitbit.bluetooth.fbgatt.btcopies.BluetoothGattDescriptorCopy;
 import android.bluetooth.BluetoothGatt;
 import android.bluetooth.BluetoothGattCharacteristic;
 import android.bluetooth.BluetoothGattDescriptor;
-import android.support.annotation.Nullable;
+import androidx.annotation.Nullable;
 
 /**
  * Interface for subscribers who want to listen directly to gatt client events.  These callbacks are

--- a/src/main/java/com/fitbit/bluetooth/fbgatt/GattConnection.java
+++ b/src/main/java/com/fitbit/bluetooth/fbgatt/GattConnection.java
@@ -18,9 +18,9 @@ import android.bluetooth.BluetoothProfile;
 import android.os.Build;
 import android.os.Handler;
 import android.os.Looper;
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
-import android.support.annotation.VisibleForTesting;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.annotation.VisibleForTesting;
 
 import java.io.Closeable;
 import java.util.ArrayList;
@@ -312,10 +312,6 @@ public class GattConnection implements Closeable {
     @VisibleForTesting
     public void setMockMode(boolean mockMode) {
         this.mockMode = mockMode;
-        // if any device goes into mock mode, let's put the scanner into mock mode
-        if (FitbitGatt.getInstance().isStarted() && FitbitGatt.getInstance().getPeripheralScanner() != null) {
-            FitbitGatt.getInstance().getPeripheralScanner().setMockMode(mockMode);
-        }
     }
 
     /* ------------------------------- dispatch ----------------------------------------------- */

--- a/src/main/java/com/fitbit/bluetooth/fbgatt/GattServerCallback.java
+++ b/src/main/java/com/fitbit/bluetooth/fbgatt/GattServerCallback.java
@@ -20,8 +20,8 @@ import android.os.Build;
 import android.os.Handler;
 import android.os.HandlerThread;
 import android.os.Looper;
-import android.support.annotation.Nullable;
-import android.support.annotation.VisibleForTesting;
+import androidx.annotation.Nullable;
+import androidx.annotation.VisibleForTesting;
 
 import com.fitbit.bluetooth.fbgatt.btcopies.BluetoothGattCharacteristicCopy;
 import com.fitbit.bluetooth.fbgatt.btcopies.BluetoothGattDescriptorCopy;

--- a/src/main/java/com/fitbit/bluetooth/fbgatt/GattServerConnection.java
+++ b/src/main/java/com/fitbit/bluetooth/fbgatt/GattServerConnection.java
@@ -14,15 +14,12 @@ import android.bluetooth.BluetoothProfile;
 import android.os.Build;
 import android.os.Handler;
 import android.os.Looper;
-import android.os.SystemClock;
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
-import android.support.annotation.VisibleForTesting;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.annotation.VisibleForTesting;
 
 import java.util.ArrayList;
 import java.util.HashSet;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 
 import timber.log.Timber;

--- a/src/main/java/com/fitbit/bluetooth/fbgatt/GattStateTransitionValidator.java
+++ b/src/main/java/com/fitbit/bluetooth/fbgatt/GattStateTransitionValidator.java
@@ -11,8 +11,7 @@ package com.fitbit.bluetooth.fbgatt;
 import com.fitbit.bluetooth.fbgatt.tx.SetClientConnectionStateTransaction;
 import com.fitbit.bluetooth.fbgatt.tx.SetServerConnectionStateTransaction;
 
-import android.support.annotation.NonNull;
-
+import androidx.annotation.NonNull;
 import timber.log.Timber;
 
 import static com.fitbit.bluetooth.fbgatt.GattStateTransitionValidator.GuardState.INVALID_TARGET_STATE;

--- a/src/main/java/com/fitbit/bluetooth/fbgatt/GattTransaction.java
+++ b/src/main/java/com/fitbit/bluetooth/fbgatt/GattTransaction.java
@@ -8,6 +8,11 @@
 
 package com.fitbit.bluetooth.fbgatt;
 
+import com.fitbit.bluetooth.fbgatt.btcopies.BluetoothGattCharacteristicCopy;
+import com.fitbit.bluetooth.fbgatt.btcopies.BluetoothGattDescriptorCopy;
+import com.fitbit.bluetooth.fbgatt.tx.GattConnectTransaction;
+import com.fitbit.bluetooth.fbgatt.util.GattUtils;
+
 import android.bluetooth.BluetoothDevice;
 import android.bluetooth.BluetoothGatt;
 import android.bluetooth.BluetoothGattService;
@@ -15,15 +20,6 @@ import android.content.Context;
 import android.os.Build;
 import android.os.Handler;
 import android.os.Looper;
-import android.support.annotation.CallSuper;
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
-import android.support.annotation.VisibleForTesting;
-
-import com.fitbit.bluetooth.fbgatt.btcopies.BluetoothGattCharacteristicCopy;
-import com.fitbit.bluetooth.fbgatt.btcopies.BluetoothGattDescriptorCopy;
-import com.fitbit.bluetooth.fbgatt.tx.GattConnectTransaction;
-import com.fitbit.bluetooth.fbgatt.util.GattUtils;
 
 import java.util.ArrayList;
 import java.util.Locale;
@@ -32,6 +28,10 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import androidx.annotation.CallSuper;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.annotation.VisibleForTesting;
 import timber.log.Timber;
 
 /**

--- a/src/main/java/com/fitbit/bluetooth/fbgatt/GattTransactionCallback.java
+++ b/src/main/java/com/fitbit/bluetooth/fbgatt/GattTransactionCallback.java
@@ -8,8 +8,8 @@
 
 package com.fitbit.bluetooth.fbgatt;
 
-import android.support.annotation.MainThread;
-import android.support.annotation.NonNull;
+import androidx.annotation.MainThread;
+import androidx.annotation.NonNull;
 
 /**
  * The callback via which we deliver the result of the gatt transaction, must always be delivered

--- a/src/main/java/com/fitbit/bluetooth/fbgatt/HandleIntentBasedScanResult.java
+++ b/src/main/java/com/fitbit/bluetooth/fbgatt/HandleIntentBasedScanResult.java
@@ -17,7 +17,7 @@ import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
 import android.os.Build;
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import com.fitbit.bluetooth.fbgatt.util.GattUtils;
 import com.fitbit.bluetooth.fbgatt.util.ScanFailedReason;

--- a/src/main/java/com/fitbit/bluetooth/fbgatt/LowEnergyAclListener.java
+++ b/src/main/java/com/fitbit/bluetooth/fbgatt/LowEnergyAclListener.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2019 Fitbit, Inc. All rights reserved.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+package com.fitbit.bluetooth.fbgatt;
+
+import com.fitbit.bluetooth.fbgatt.tx.GattDisconnectTransaction;
+
+import android.bluetooth.BluetoothDevice;
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+import android.content.IntentFilter;
+
+import timber.log.Timber;
+
+/**
+ * ACL callback listener for fitbit gatt, will respond to peripheral connections to phone, and
+ * disconnections from the phone. Note, this does not necessarily respond to disconnections / connections
+ * from / to your process, I.E. BluetoothGatt#connect(...) / BluetoothDevice#connectGatt(...), and
+ * BluetoothGatt#disconnect()
+ *
+ * Created by iowens on 7/19/19.
+ */
+
+public class LowEnergyAclListener extends BroadcastReceiver {
+    private IntentFilter[] filters = {
+        new IntentFilter(BluetoothDevice.ACTION_FOUND),
+        new IntentFilter(BluetoothDevice.ACTION_ACL_DISCONNECTED),
+        new IntentFilter(BluetoothDevice.ACTION_ACL_CONNECTED),
+        new IntentFilter(BluetoothDevice.ACTION_ACL_DISCONNECT_REQUESTED)
+    };
+
+    void register(Context context) {
+        for (IntentFilter f : filters) {
+            context.registerReceiver(this, f);
+        }
+    }
+
+
+    @Override
+    public void onReceive(Context context, Intent intent) {
+        String action = intent.getAction();
+        BluetoothDevice device = intent.getParcelableExtra(BluetoothDevice.EXTRA_DEVICE);
+        Timber.i("BT change received !");
+        if (device == null) {
+            Timber.d("BT Device is null");
+            return;
+        }
+        FitbitBluetoothDevice fbDevice = new FitbitBluetoothDevice(device);
+        if (BluetoothDevice.ACTION_FOUND.equals(action)) {
+            Timber.i("%s Device found", device.getName());
+            // device was discovered in scan but we don't necessarily want to just add it unless
+            // it's connected to the phone
+        }
+        if (BluetoothDevice.ACTION_ACL_CONNECTED.equals(action)) {
+            Timber.i("%s Device is now connected", device.getName());
+            // device was connected to the phone, does not mean device is connected to the
+            // app, this can create a new connection because we are certain that the connection
+            // is not in the cache already
+            if (!FitbitGatt.getInstance().isDeviceInConnections(fbDevice)) {
+                FitbitGatt.getInstance().putConnectionIntoDevices(fbDevice, new GattConnection(fbDevice, context.getMainLooper()));
+            }
+        }
+        if (BluetoothDevice.ACTION_ACL_DISCONNECTED.equals(action)) {
+            Timber.i("%s Device is disconnected", device.getName());
+            GattConnection gattConnection = FitbitGatt.getInstance().getConnection(fbDevice);
+            if (gattConnection != null) {
+                // we must use the transaction because if we do not the connection will not be
+                // blocked and a caller can perform some operation on a disconnecting device
+                GattDisconnectTransaction tx = new GattDisconnectTransaction(gattConnection, GattState.DISCONNECTED);
+                gattConnection.runTx(tx, result -> {
+                    if (result.resultStatus.equals(TransactionResult.TransactionResultStatus.SUCCESS)) {
+                        Timber.v("Successful disconnection");
+                    } else if (result.resultStatus.equals(TransactionResult.TransactionResultStatus.INVALID_STATE)) {
+                        Timber.i("The disconnect is being handled at the callback level");
+                    } else {
+                        Timber.w("Failed to disconnect");
+                    }
+                    Timber.i("%s Notifying listeners of connection disconnected", device.getName());
+                    if (FitbitGatt.getInstance().getPeripheralScanner() != null) {
+                        FitbitGatt.getInstance().getPeripheralScanner().onDeviceDisconnected(device);
+                    }
+                    FitbitGatt.getInstance().notifyListenersOfConnectionDisconnected(gattConnection);
+                });
+            }
+        }
+    }
+}

--- a/src/main/java/com/fitbit/bluetooth/fbgatt/ScannerInterface.java
+++ b/src/main/java/com/fitbit/bluetooth/fbgatt/ScannerInterface.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2019 Fitbit, Inc. All rights reserved.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+package com.fitbit.bluetooth.fbgatt;
+
+import android.app.PendingIntent;
+import android.bluetooth.le.ScanCallback;
+import android.bluetooth.le.ScanFilter;
+import android.bluetooth.le.ScanSettings;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import java.util.List;
+
+/**
+ * We place the scanner behind an interface so that we can replace the android scanner with a mock
+ * scanner in unit tests
+ *
+ * Created by iowens on 06/11/19.
+ */
+
+public interface ScannerInterface {
+    /**
+     * Starts a scan with a given scan callback for delivering results
+     * @param callback The scan callback
+     */
+    void startScan(final ScanCallback callback);
+
+    /**
+     * Starts a bluetooth scan with filters
+     * @param filters Scan filters
+     * @param settings Scan settings
+     * @param callback The scan callback
+     */
+    void startScan(List<ScanFilter> filters, ScanSettings settings,
+                          final ScanCallback callback);
+
+    /**
+     * Starts a scan with a list of filters, scan settings and delivers results with a pending intent
+     * callback
+     * @param filters Scan filters
+     * @param settings Scan settings
+     * @param callbackIntent The callback intent to be delivered when devices matching the scan
+     *                       filters are discovered
+     * @return an integer corresponding to the ScanCallback error message
+     */
+    int startScan(@Nullable List<ScanFilter> filters, @Nullable ScanSettings settings,
+                         @NonNull PendingIntent callbackIntent);
+
+    /**
+     * Will stop the scanner
+     * @param callback Will stop a scanner with the given callback ( should match )
+     */
+    void stopScan(ScanCallback callback);
+
+    /**
+     * Will stop the scan for the given intent
+     * @param callbackIntent The callback intent to be delivered when devices are discovered
+     */
+    void stopScan(PendingIntent callbackIntent);
+
+    /**
+     * Internal method to the scanner to flush pending results
+     * @param callback The scanner callback
+     */
+    void flushPendingScanResults(ScanCallback callback);
+
+    /**
+     * Will interact with the adapter to determine if BT is on / off
+     * @return True if BT is on, false if it is off
+     */
+    boolean isBluetoothEnabled();
+
+    /**
+     * Internal method to the scanner to clean-up resources
+     */
+    void cleanup();
+}

--- a/src/main/java/com/fitbit/bluetooth/fbgatt/ServerConnectionEventListener.java
+++ b/src/main/java/com/fitbit/bluetooth/fbgatt/ServerConnectionEventListener.java
@@ -9,7 +9,7 @@
 package com.fitbit.bluetooth.fbgatt;
 
 import android.bluetooth.BluetoothDevice;
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 /**
  * Will allow a connection user to establish a listener for asynchronous events from the gatt

--- a/src/main/java/com/fitbit/bluetooth/fbgatt/StrategyProvider.java
+++ b/src/main/java/com/fitbit/bluetooth/fbgatt/StrategyProvider.java
@@ -9,8 +9,8 @@
 package com.fitbit.bluetooth.fbgatt;
 
 import android.os.Build;
-import android.support.annotation.Nullable;
-import android.support.annotation.VisibleForTesting;
+import androidx.annotation.Nullable;
+import androidx.annotation.VisibleForTesting;
 
 import com.fitbit.bluetooth.fbgatt.strategies.DelaySubscriptionResultStrategy;
 import com.fitbit.bluetooth.fbgatt.strategies.HandleTrackerVanishingUnderGattOperationStrategy;

--- a/src/main/java/com/fitbit/bluetooth/fbgatt/TransactionResult.java
+++ b/src/main/java/com/fitbit/bluetooth/fbgatt/TransactionResult.java
@@ -14,8 +14,8 @@ import com.fitbit.bluetooth.fbgatt.util.GattStatus;
 import android.bluetooth.BluetoothDevice;
 import android.bluetooth.BluetoothGattCharacteristic;
 import android.bluetooth.BluetoothGattService;
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/src/main/java/com/fitbit/bluetooth/fbgatt/logging/BitgattDebugTree.java
+++ b/src/main/java/com/fitbit/bluetooth/fbgatt/logging/BitgattDebugTree.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2019 Fitbit, Inc. All rights reserved.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+package com.fitbit.bluetooth.fbgatt.logging;
+
+import android.os.Build;
+import android.util.Log;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import timber.log.Timber;
+
+/**
+ * Timber tree for debug logging
+ */
+
+public class BitgattDebugTree extends Timber.DebugTree {
+    private static final int MAX_LOG_LENGTH = 4000;
+    @Override
+    protected void log(int priority, @Nullable String tag, @NotNull String message, @Nullable Throwable t) {
+        // Workaround for devices that doesn't show lower priority logs
+        if(Build.MANUFACTURER == null) {
+            return;
+        }
+        if (Build.MANUFACTURER.equals("HUAWEI") || Build.MANUFACTURER.equals("samsung")) {
+            if (priority == Log.VERBOSE || priority == Log.DEBUG || priority == Log.INFO)
+                priority = Log.ERROR;
+        }
+        if (priority >= Log.WARN) {
+            if(message.length() < MAX_LOG_LENGTH) {
+                super.log(priority, tag, message, t);
+                return;
+            }
+            splitLogMessage(priority, tag, message, t);
+        } else {
+            if(message.length() < MAX_LOG_LENGTH) {
+                super.log(priority, tag, message, t);
+                return;
+            }
+            splitLogMessage(priority, tag, message, t);
+        }
+    }
+
+    static void splitLogMessage(int priority, String tag, String message, Throwable t) {
+        // Split by line, then ensure each line can fit into Log's maximum length.
+        for (int i = 0, length = message.length(); i < length; i++) {
+            int newline = message.indexOf('\n', i);
+            newline = newline != -1 ? newline : length;
+            do {
+                int end = Math.min(newline, i + MAX_LOG_LENGTH);
+                String part = message.substring(i, end);
+                Log.println(priority, tag, part);
+                i = end;
+            } while (i < newline);
+        }
+    }
+}

--- a/src/main/java/com/fitbit/bluetooth/fbgatt/logging/BitgattReleaseTree.java
+++ b/src/main/java/com/fitbit/bluetooth/fbgatt/logging/BitgattReleaseTree.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2019 Fitbit, Inc. All rights reserved.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+package com.fitbit.bluetooth.fbgatt.logging;
+
+import android.util.Log;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import timber.log.Timber;
+
+/**
+ * Timber tree for release logging
+ */
+
+public class BitgattReleaseTree extends Timber.Tree {
+    private static final int MAX_LOG_LENGTH = 4000;
+
+    @Override
+    protected void log(int priority, @Nullable String tag, @NotNull String message, @Nullable Throwable t) {
+        if(priority >= Log.WARN) {
+            if (message.length() < MAX_LOG_LENGTH) {
+                Log.println(priority, tag, message);
+                return;
+            }
+            BitgattDebugTree.splitLogMessage(priority, tag, message, t);
+        }
+    }
+}

--- a/src/main/java/com/fitbit/bluetooth/fbgatt/tx/AddGattServerServiceTransaction.java
+++ b/src/main/java/com/fitbit/bluetooth/fbgatt/tx/AddGattServerServiceTransaction.java
@@ -81,7 +81,7 @@ public class AddGattServerServiceTransaction extends GattServerTransaction {
                 TransactionResult.Builder builder = new TransactionResult.Builder().transactionName(getName());
                 builder.responseStatus(GattDisconnectReason.getReasonForCode(GattDisconnectReason.GATT_CONN_NO_RESOURCES.getCode()).ordinal());
                 getGattServer().setState(GattState.ADD_SERVICE_FAILURE);
-                Timber.w("The gatt service %s failed to be added at the gatt level, try again later.", service.getUuid());
+                Timber.w("The gatt service %s, failed to be added at the gatt level, try again later.", service.getUuid());
                 builder.gattState(getGattServer().getGattState())
                     .serviceUuid(service.getUuid())
                     .resultStatus(TransactionResult.TransactionResultStatus.FAILURE);

--- a/src/main/java/com/fitbit/bluetooth/fbgatt/tx/CloseGattTransaction.java
+++ b/src/main/java/com/fitbit/bluetooth/fbgatt/tx/CloseGattTransaction.java
@@ -15,7 +15,7 @@ import com.fitbit.bluetooth.fbgatt.GattTransactionCallback;
 import com.fitbit.bluetooth.fbgatt.TransactionResult;
 
 import android.bluetooth.BluetoothGatt;
-import android.support.annotation.Nullable;
+import androidx.annotation.Nullable;
 
 import timber.log.Timber;
 

--- a/src/main/java/com/fitbit/bluetooth/fbgatt/tx/CreateBondTransaction.java
+++ b/src/main/java/com/fitbit/bluetooth/fbgatt/tx/CreateBondTransaction.java
@@ -23,8 +23,8 @@ import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
-import android.support.annotation.Nullable;
-import android.support.annotation.VisibleForTesting;
+import androidx.annotation.Nullable;
+import androidx.annotation.VisibleForTesting;
 
 import java.util.concurrent.TimeUnit;
 
@@ -68,11 +68,11 @@ public class CreateBondTransaction extends GattTransaction {
                 if (getConnection().getDevice().equals(extraDevice)) {
                     int oldState = intent.getIntExtra(BluetoothDevice.EXTRA_PREVIOUS_BOND_STATE, BluetoothDevice.BOND_NONE);
                     int newState = intent.getIntExtra(BluetoothDevice.EXTRA_BOND_STATE, BluetoothDevice.BOND_NONE);
-                    GattUtils utils = new GattUtils();
+                    GattUtils util = new GattUtils();
                     Timber.d("[%s] Bond state changed from %s to %s",
                             getConnection().getDevice(),
-                            utils.getBondStateDescription(oldState),
-                            utils.getBondStateDescription(newState));
+                            util.getBondStateDescription(oldState),
+                            util.getBondStateDescription(newState));
                     switch (newState) {
                         case BluetoothDevice.BOND_BONDED:
                             Timber.d("[%s] Bond state changed to BONDED",getDevice());

--- a/src/main/java/com/fitbit/bluetooth/fbgatt/tx/GattClientDiscoverServicesTransaction.java
+++ b/src/main/java/com/fitbit/bluetooth/fbgatt/tx/GattClientDiscoverServicesTransaction.java
@@ -16,7 +16,7 @@ import com.fitbit.bluetooth.fbgatt.TransactionResult;
 import com.fitbit.bluetooth.fbgatt.util.GattStatus;
 
 import android.bluetooth.BluetoothGatt;
-import android.support.annotation.Nullable;
+import androidx.annotation.Nullable;
 
 import timber.log.Timber;
 

--- a/src/main/java/com/fitbit/bluetooth/fbgatt/tx/GattClientRefreshGattTransaction.java
+++ b/src/main/java/com/fitbit/bluetooth/fbgatt/tx/GattClientRefreshGattTransaction.java
@@ -14,14 +14,12 @@ import com.fitbit.bluetooth.fbgatt.GattTransaction;
 import com.fitbit.bluetooth.fbgatt.GattTransactionCallback;
 import com.fitbit.bluetooth.fbgatt.TransactionResult;
 
-import android.annotation.SuppressLint;
 import android.bluetooth.BluetoothGatt;
-import android.support.annotation.Nullable;
+import androidx.annotation.Nullable;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
 
 import timber.log.Timber;
 

--- a/src/main/java/com/fitbit/bluetooth/fbgatt/tx/ReadGattCharacteristicTransaction.java
+++ b/src/main/java/com/fitbit/bluetooth/fbgatt/tx/ReadGattCharacteristicTransaction.java
@@ -20,7 +20,7 @@ import com.fitbit.bluetooth.fbgatt.util.GattDisconnectReason;
 
 import android.bluetooth.BluetoothGatt;
 import android.bluetooth.BluetoothGattCharacteristic;
-import android.support.annotation.Nullable;
+import androidx.annotation.Nullable;
 
 import timber.log.Timber;
 

--- a/src/main/java/com/fitbit/bluetooth/fbgatt/tx/ReadGattDescriptorTransaction.java
+++ b/src/main/java/com/fitbit/bluetooth/fbgatt/tx/ReadGattDescriptorTransaction.java
@@ -20,7 +20,7 @@ import com.fitbit.bluetooth.fbgatt.util.GattDisconnectReason;
 
 import android.bluetooth.BluetoothGatt;
 import android.bluetooth.BluetoothGattDescriptor;
-import android.support.annotation.Nullable;
+import androidx.annotation.Nullable;
 
 import timber.log.Timber;
 

--- a/src/main/java/com/fitbit/bluetooth/fbgatt/tx/ReadGattServerCharacteristicDescriptorValueTransaction.java
+++ b/src/main/java/com/fitbit/bluetooth/fbgatt/tx/ReadGattServerCharacteristicDescriptorValueTransaction.java
@@ -18,7 +18,7 @@ import com.fitbit.bluetooth.fbgatt.util.GattStatus;
 import android.bluetooth.BluetoothGattCharacteristic;
 import android.bluetooth.BluetoothGattDescriptor;
 import android.bluetooth.BluetoothGattService;
-import android.support.annotation.Nullable;
+import androidx.annotation.Nullable;
 
 /**
  * Will read a characteristic descriptor from a local gatt server and populate a transaction result with

--- a/src/main/java/com/fitbit/bluetooth/fbgatt/tx/ReadGattServerCharacteristicValueTransaction.java
+++ b/src/main/java/com/fitbit/bluetooth/fbgatt/tx/ReadGattServerCharacteristicValueTransaction.java
@@ -17,7 +17,7 @@ import com.fitbit.bluetooth.fbgatt.util.GattStatus;
 
 import android.bluetooth.BluetoothGattCharacteristic;
 import android.bluetooth.BluetoothGattService;
-import android.support.annotation.Nullable;
+import androidx.annotation.Nullable;
 
 /**
  * Will read a characteristic from a local gatt server and populate a transaction result with

--- a/src/main/java/com/fitbit/bluetooth/fbgatt/tx/ReadRssiTransaction.java
+++ b/src/main/java/com/fitbit/bluetooth/fbgatt/tx/ReadRssiTransaction.java
@@ -9,7 +9,7 @@
 package com.fitbit.bluetooth.fbgatt.tx;
 
 import android.bluetooth.BluetoothGatt;
-import android.support.annotation.Nullable;
+import androidx.annotation.Nullable;
 
 import com.fitbit.bluetooth.fbgatt.GattConnection;
 import com.fitbit.bluetooth.fbgatt.GattState;

--- a/src/main/java/com/fitbit/bluetooth/fbgatt/tx/RequestGattConnectionIntervalTransaction.java
+++ b/src/main/java/com/fitbit/bluetooth/fbgatt/tx/RequestGattConnectionIntervalTransaction.java
@@ -17,7 +17,7 @@ import com.fitbit.bluetooth.fbgatt.TransactionResult;
 import com.fitbit.bluetooth.fbgatt.util.GattStatus;
 
 import android.bluetooth.BluetoothGatt;
-import android.support.annotation.Nullable;
+import androidx.annotation.Nullable;
 
 import timber.log.Timber;
 

--- a/src/main/java/com/fitbit/bluetooth/fbgatt/tx/RequestMtuGattTransaction.java
+++ b/src/main/java/com/fitbit/bluetooth/fbgatt/tx/RequestMtuGattTransaction.java
@@ -17,7 +17,7 @@ import com.fitbit.bluetooth.fbgatt.TransactionResult;
 import com.fitbit.bluetooth.fbgatt.util.GattDisconnectReason;
 
 import android.bluetooth.BluetoothGatt;
-import android.support.annotation.Nullable;
+import androidx.annotation.Nullable;
 
 import timber.log.Timber;
 

--- a/src/main/java/com/fitbit/bluetooth/fbgatt/tx/SetClientConnectionStateTransaction.java
+++ b/src/main/java/com/fitbit/bluetooth/fbgatt/tx/SetClientConnectionStateTransaction.java
@@ -14,7 +14,7 @@ import com.fitbit.bluetooth.fbgatt.GattTransaction;
 import com.fitbit.bluetooth.fbgatt.GattTransactionCallback;
 import com.fitbit.bluetooth.fbgatt.TransactionResult;
 
-import android.support.annotation.Nullable;
+import androidx.annotation.Nullable;
 
 import timber.log.Timber;
 

--- a/src/main/java/com/fitbit/bluetooth/fbgatt/tx/SetServerConnectionStateTransaction.java
+++ b/src/main/java/com/fitbit/bluetooth/fbgatt/tx/SetServerConnectionStateTransaction.java
@@ -14,7 +14,7 @@ import com.fitbit.bluetooth.fbgatt.GattState;
 import com.fitbit.bluetooth.fbgatt.GattTransactionCallback;
 import com.fitbit.bluetooth.fbgatt.TransactionResult;
 
-import android.support.annotation.Nullable;
+import androidx.annotation.Nullable;
 
 import timber.log.Timber;
 

--- a/src/main/java/com/fitbit/bluetooth/fbgatt/tx/SubscribeToCharacteristicNotificationsTransaction.java
+++ b/src/main/java/com/fitbit/bluetooth/fbgatt/tx/SubscribeToCharacteristicNotificationsTransaction.java
@@ -21,7 +21,7 @@ import com.fitbit.bluetooth.fbgatt.util.GattStatus;
 
 import android.bluetooth.BluetoothGatt;
 import android.bluetooth.BluetoothGattCharacteristic;
-import android.support.annotation.Nullable;
+import androidx.annotation.Nullable;
 
 import timber.log.Timber;
 

--- a/src/main/java/com/fitbit/bluetooth/fbgatt/tx/UnSubscribeToGattCharacteristicNotificationsTransaction.java
+++ b/src/main/java/com/fitbit/bluetooth/fbgatt/tx/UnSubscribeToGattCharacteristicNotificationsTransaction.java
@@ -15,14 +15,13 @@ import com.fitbit.bluetooth.fbgatt.GattTransaction;
 import com.fitbit.bluetooth.fbgatt.GattTransactionCallback;
 import com.fitbit.bluetooth.fbgatt.Situation;
 import com.fitbit.bluetooth.fbgatt.TransactionResult;
-import com.fitbit.bluetooth.fbgatt.btcopies.BluetoothGattCharacteristicCopy;
 import com.fitbit.bluetooth.fbgatt.strategies.Strategy;
 import com.fitbit.bluetooth.fbgatt.util.GattDisconnectReason;
 import com.fitbit.bluetooth.fbgatt.util.GattStatus;
 
 import android.bluetooth.BluetoothGatt;
 import android.bluetooth.BluetoothGattCharacteristic;
-import android.support.annotation.Nullable;
+import androidx.annotation.Nullable;
 
 import timber.log.Timber;
 

--- a/src/main/java/com/fitbit/bluetooth/fbgatt/tx/WriteGattCharacteristicTransaction.java
+++ b/src/main/java/com/fitbit/bluetooth/fbgatt/tx/WriteGattCharacteristicTransaction.java
@@ -20,7 +20,7 @@ import com.fitbit.bluetooth.fbgatt.util.GattDisconnectReason;
 
 import android.bluetooth.BluetoothGatt;
 import android.bluetooth.BluetoothGattCharacteristic;
-import android.support.annotation.Nullable;
+import androidx.annotation.Nullable;
 
 import timber.log.Timber;
 

--- a/src/main/java/com/fitbit/bluetooth/fbgatt/tx/WriteGattDescriptorTransaction.java
+++ b/src/main/java/com/fitbit/bluetooth/fbgatt/tx/WriteGattDescriptorTransaction.java
@@ -20,7 +20,7 @@ import com.fitbit.bluetooth.fbgatt.util.GattDisconnectReason;
 
 import android.bluetooth.BluetoothGatt;
 import android.bluetooth.BluetoothGattDescriptor;
-import android.support.annotation.Nullable;
+import androidx.annotation.Nullable;
 
 import timber.log.Timber;
 

--- a/src/main/java/com/fitbit/bluetooth/fbgatt/tx/WriteGattServerCharacteristicDescriptorValueTransaction.java
+++ b/src/main/java/com/fitbit/bluetooth/fbgatt/tx/WriteGattServerCharacteristicDescriptorValueTransaction.java
@@ -20,7 +20,7 @@ import com.fitbit.bluetooth.fbgatt.util.GattStatus;
 import android.bluetooth.BluetoothGattCharacteristic;
 import android.bluetooth.BluetoothGattDescriptor;
 import android.bluetooth.BluetoothGattService;
-import android.support.annotation.Nullable;
+import androidx.annotation.Nullable;
 
 import timber.log.Timber;
 

--- a/src/main/java/com/fitbit/bluetooth/fbgatt/tx/WriteGattServerCharacteristicValueTransaction.java
+++ b/src/main/java/com/fitbit/bluetooth/fbgatt/tx/WriteGattServerCharacteristicValueTransaction.java
@@ -19,7 +19,7 @@ import com.fitbit.bluetooth.fbgatt.util.GattStatus;
 
 import android.bluetooth.BluetoothGattCharacteristic;
 import android.bluetooth.BluetoothGattService;
-import android.support.annotation.Nullable;
+import androidx.annotation.Nullable;
 
 import timber.log.Timber;
 

--- a/src/main/java/com/fitbit/bluetooth/fbgatt/tx/mocks/CloseGattMockTransaction.java
+++ b/src/main/java/com/fitbit/bluetooth/fbgatt/tx/mocks/CloseGattMockTransaction.java
@@ -9,7 +9,7 @@
 package com.fitbit.bluetooth.fbgatt.tx.mocks;
 
 import android.os.Handler;
-import android.support.annotation.Nullable;
+import androidx.annotation.Nullable;
 
 import com.fitbit.bluetooth.fbgatt.GattConnection;
 import com.fitbit.bluetooth.fbgatt.GattState;

--- a/src/main/java/com/fitbit/bluetooth/fbgatt/tx/mocks/GattClientDiscoverMockServicesTransaction.java
+++ b/src/main/java/com/fitbit/bluetooth/fbgatt/tx/mocks/GattClientDiscoverMockServicesTransaction.java
@@ -10,7 +10,7 @@ package com.fitbit.bluetooth.fbgatt.tx.mocks;
 
 import android.bluetooth.BluetoothGattService;
 import android.os.Handler;
-import android.support.annotation.Nullable;
+import androidx.annotation.Nullable;
 
 import com.fitbit.bluetooth.fbgatt.GattConnection;
 import com.fitbit.bluetooth.fbgatt.GattState;

--- a/src/main/java/com/fitbit/bluetooth/fbgatt/tx/mocks/MockNoOpTransaction.java
+++ b/src/main/java/com/fitbit/bluetooth/fbgatt/tx/mocks/MockNoOpTransaction.java
@@ -16,7 +16,7 @@ import com.fitbit.bluetooth.fbgatt.GattTransactionCallback;
 import com.fitbit.bluetooth.fbgatt.TransactionResult;
 
 import android.os.SystemClock;
-import android.support.annotation.Nullable;
+import androidx.annotation.Nullable;
 
 import org.jetbrains.annotations.TestOnly;
 

--- a/src/main/java/com/fitbit/bluetooth/fbgatt/tx/mocks/ReadGattCharacteristicMockTransaction.java
+++ b/src/main/java/com/fitbit/bluetooth/fbgatt/tx/mocks/ReadGattCharacteristicMockTransaction.java
@@ -20,8 +20,8 @@ import com.fitbit.bluetooth.fbgatt.util.GattUtils;
 import android.bluetooth.BluetoothGatt;
 import android.bluetooth.BluetoothGattCharacteristic;
 import android.os.Handler;
-import android.support.annotation.Nullable;
-import android.support.annotation.VisibleForTesting;
+import androidx.annotation.Nullable;
+import androidx.annotation.VisibleForTesting;
 
 import timber.log.Timber;
 

--- a/src/main/java/com/fitbit/bluetooth/fbgatt/tx/mocks/ReadGattDescriptorMockTransaction.java
+++ b/src/main/java/com/fitbit/bluetooth/fbgatt/tx/mocks/ReadGattDescriptorMockTransaction.java
@@ -10,7 +10,7 @@ package com.fitbit.bluetooth.fbgatt.tx.mocks;
 
 import android.bluetooth.BluetoothGattDescriptor;
 import android.os.Handler;
-import android.support.annotation.Nullable;
+import androidx.annotation.Nullable;
 
 import com.fitbit.bluetooth.fbgatt.GattConnection;
 import com.fitbit.bluetooth.fbgatt.GattState;

--- a/src/main/java/com/fitbit/bluetooth/fbgatt/tx/mocks/ReadRssiMockTransaction.java
+++ b/src/main/java/com/fitbit/bluetooth/fbgatt/tx/mocks/ReadRssiMockTransaction.java
@@ -15,7 +15,7 @@ import com.fitbit.bluetooth.fbgatt.TransactionResult;
 import com.fitbit.bluetooth.fbgatt.tx.ReadRssiTransaction;
 
 import android.os.Handler;
-import android.support.annotation.Nullable;
+import androidx.annotation.Nullable;
 
 import java.util.Random;
 

--- a/src/main/java/com/fitbit/bluetooth/fbgatt/tx/mocks/RequestGattConnectionIntervalMockTransaction.java
+++ b/src/main/java/com/fitbit/bluetooth/fbgatt/tx/mocks/RequestGattConnectionIntervalMockTransaction.java
@@ -16,7 +16,7 @@ import com.fitbit.bluetooth.fbgatt.tx.RequestGattConnectionIntervalTransaction;
 import com.fitbit.bluetooth.fbgatt.util.GattStatus;
 
 import android.os.Handler;
-import android.support.annotation.Nullable;
+import androidx.annotation.Nullable;
 
 import timber.log.Timber;
 

--- a/src/main/java/com/fitbit/bluetooth/fbgatt/tx/mocks/RequestMtuGattMockTransaction.java
+++ b/src/main/java/com/fitbit/bluetooth/fbgatt/tx/mocks/RequestMtuGattMockTransaction.java
@@ -15,7 +15,7 @@ import com.fitbit.bluetooth.fbgatt.tx.RequestMtuGattTransaction;
 
 import android.bluetooth.BluetoothGatt;
 import android.os.Handler;
-import android.support.annotation.Nullable;
+import androidx.annotation.Nullable;
 
 /**
  * Mock class for requesting an MTU change

--- a/src/main/java/com/fitbit/bluetooth/fbgatt/tx/mocks/SubscribeToCharacteristicNotificationsMockTransaction.java
+++ b/src/main/java/com/fitbit/bluetooth/fbgatt/tx/mocks/SubscribeToCharacteristicNotificationsMockTransaction.java
@@ -16,7 +16,7 @@ import com.fitbit.bluetooth.fbgatt.tx.SubscribeToCharacteristicNotificationsTran
 
 import android.bluetooth.BluetoothGattCharacteristic;
 import android.os.Handler;
-import android.support.annotation.Nullable;
+import androidx.annotation.Nullable;
 
 /**
  * Mocks the subscription, will process through for success, fail in this case will be a timeout

--- a/src/main/java/com/fitbit/bluetooth/fbgatt/tx/mocks/UnSubscribeToGattCharacteristicNotificationsMockTransaction.java
+++ b/src/main/java/com/fitbit/bluetooth/fbgatt/tx/mocks/UnSubscribeToGattCharacteristicNotificationsMockTransaction.java
@@ -16,7 +16,7 @@ import com.fitbit.bluetooth.fbgatt.tx.UnSubscribeToGattCharacteristicNotificatio
 
 import android.bluetooth.BluetoothGattCharacteristic;
 import android.os.Handler;
-import android.support.annotation.Nullable;
+import androidx.annotation.Nullable;
 
 /**
  * A mock unsubscribe transaction

--- a/src/main/java/com/fitbit/bluetooth/fbgatt/tx/mocks/WriteGattCharacteristicMockTransaction.java
+++ b/src/main/java/com/fitbit/bluetooth/fbgatt/tx/mocks/WriteGattCharacteristicMockTransaction.java
@@ -10,7 +10,7 @@ package com.fitbit.bluetooth.fbgatt.tx.mocks;
 
 import android.bluetooth.BluetoothGattCharacteristic;
 import android.os.Handler;
-import android.support.annotation.Nullable;
+import androidx.annotation.Nullable;
 
 import com.fitbit.bluetooth.fbgatt.GattConnection;
 import com.fitbit.bluetooth.fbgatt.GattState;

--- a/src/main/java/com/fitbit/bluetooth/fbgatt/tx/mocks/WriteGattDescriptorMockTransaction.java
+++ b/src/main/java/com/fitbit/bluetooth/fbgatt/tx/mocks/WriteGattDescriptorMockTransaction.java
@@ -18,8 +18,8 @@ import com.fitbit.bluetooth.fbgatt.util.GattUtils;
 
 import android.bluetooth.BluetoothGattDescriptor;
 import android.os.Handler;
-import android.support.annotation.Nullable;
-import android.support.annotation.VisibleForTesting;
+import androidx.annotation.Nullable;
+import androidx.annotation.VisibleForTesting;
 
 /**
  * The mock write gatt descriptor mock transaction

--- a/src/main/java/com/fitbit/bluetooth/fbgatt/util/GattUtils.java
+++ b/src/main/java/com/fitbit/bluetooth/fbgatt/util/GattUtils.java
@@ -12,6 +12,7 @@ import com.fitbit.bluetooth.fbgatt.btcopies.BluetoothGattCharacteristicCopy;
 import com.fitbit.bluetooth.fbgatt.btcopies.BluetoothGattDescriptorCopy;
 import com.fitbit.bluetooth.fbgatt.btcopies.BluetoothGattServiceCopy;
 
+import android.bluetooth.BluetoothClass;
 import android.bluetooth.BluetoothAdapter;
 import android.bluetooth.BluetoothDevice;
 import android.bluetooth.BluetoothGatt;
@@ -21,7 +22,7 @@ import android.bluetooth.BluetoothGattService;
 import android.bluetooth.BluetoothManager;
 import android.bluetooth.BluetoothProfile;
 import android.content.Context;
-import android.support.annotation.Nullable;
+import androidx.annotation.Nullable;
 
 import java.util.Arrays;
 import java.util.List;
@@ -253,4 +254,177 @@ public class GattUtils {
         }
     }
 
+    /**
+     * Will take an int from the Major Device Class and translate it into a string
+     *
+     * @param devType The device type numerical value
+     * @return The string value
+     */
+
+    public String getDevTypeDescription(int devType) {
+        switch (devType) {
+            case BluetoothDevice.DEVICE_TYPE_CLASSIC:
+                return "CLASSIC";
+            case BluetoothDevice.DEVICE_TYPE_DUAL:
+                return "DUAL";
+            case BluetoothDevice.DEVICE_TYPE_LE:
+                return "LE";
+            case BluetoothDevice.DEVICE_TYPE_UNKNOWN:
+                return "UNKNOWN";
+            default:
+                return "UNKNOWN" + Integer.toString(devType);
+        }
+    }
+
+    /**
+     * Will take an int from the Major Device Class and translate it into a string
+     *
+     * @param majDevClass The major device class numerical value
+     * @return The string value
+     */
+
+    public String getMajDevClassDescription(int majDevClass) {
+        switch (majDevClass) {
+            case BluetoothClass.Device.Major.AUDIO_VIDEO:
+                return "AUDIO_VIDEO";
+            case BluetoothClass.Device.Major.COMPUTER:
+                return "COMPUTER";
+            case BluetoothClass.Device.Major.HEALTH:
+                return "HEALTH";
+            case BluetoothClass.Device.Major.IMAGING:
+                return "IMAGING";
+            case BluetoothClass.Device.Major.MISC:
+                return "MISC";
+            case BluetoothClass.Device.Major.NETWORKING:
+                return "NETWORKING";
+            case BluetoothClass.Device.Major.PERIPHERAL:
+                return "PERIPHERAL";
+            case BluetoothClass.Device.Major.PHONE:
+                return "PHONE";
+            case BluetoothClass.Device.Major.TOY:
+                return "TOY";
+            case BluetoothClass.Device.Major.UNCATEGORIZED:
+                return "UNCATEGORIZED";
+            case BluetoothClass.Device.Major.WEARABLE:
+                return "WEARABLE";
+            default:
+                return "UNKNOWN" + Integer.toString(majDevClass);
+        }
+    }
+
+    /**
+     * Will take an int from the Device Class and translate it into a string
+     *
+     * @param devClass The device class numerical value
+     * @return The string value
+     */
+
+    public String getDevClassDescription(int devClass) {
+        switch (devClass) {
+            case BluetoothClass.Device.AUDIO_VIDEO_CAMCORDER:
+                return "AUDIO_VIDEO_CAMCORDER";
+            case BluetoothClass.Device.AUDIO_VIDEO_CAR_AUDIO:
+                return "AUDIO_VIDEO_CAR_AUDIO";
+            case BluetoothClass.Device.AUDIO_VIDEO_HANDSFREE:
+                return "AUDIO_VIDEO_HANDSFREE";
+            case BluetoothClass.Device.AUDIO_VIDEO_HEADPHONES:
+                return "AUDIO_VIDEO_HEADPHONES";
+            case BluetoothClass.Device.AUDIO_VIDEO_HIFI_AUDIO:
+                return "AUDIO_VIDEO_HIFI_AUDIO";
+            case BluetoothClass.Device.AUDIO_VIDEO_LOUDSPEAKER:
+                return "AUDIO_VIDEO_LOUDSPEAKER";
+            case BluetoothClass.Device.AUDIO_VIDEO_MICROPHONE:
+                return "AUDIO_VIDEO_MICROPHONE";
+            case BluetoothClass.Device.AUDIO_VIDEO_PORTABLE_AUDIO:
+                return "AUDIO_VIDEO_PORTABLE_AUDIO";
+            case BluetoothClass.Device.AUDIO_VIDEO_SET_TOP_BOX:
+                return "AUDIO_VIDEO_SET_TOP_BOX";
+            case BluetoothClass.Device.AUDIO_VIDEO_UNCATEGORIZED:
+                return "AUDIO_VIDEO_UNCATEGORIZED";
+            case BluetoothClass.Device.AUDIO_VIDEO_VCR:
+                return "AUDIO_VIDEO_VCR";
+            case BluetoothClass.Device.AUDIO_VIDEO_VIDEO_CAMERA:
+                return "AUDIO_VIDEO_VIDEO_CAMERA";
+            case BluetoothClass.Device.AUDIO_VIDEO_VIDEO_CONFERENCING:
+                return "AUDIO_VIDEO_VIDEO_CONFERENCING";
+            case BluetoothClass.Device.AUDIO_VIDEO_VIDEO_DISPLAY_AND_LOUDSPEAKER:
+                return "AUDIO_VIDEO_VIDEO_DISPLAY_AND_LOUDSPEAKER";
+            case BluetoothClass.Device.AUDIO_VIDEO_VIDEO_GAMING_TOY:
+                return "AUDIO_VIDEO_VIDEO_GAMING_TOY";
+            case BluetoothClass.Device.AUDIO_VIDEO_VIDEO_MONITOR:
+                return "AUDIO_VIDEO_VIDEO_MONITOR";
+            case BluetoothClass.Device.AUDIO_VIDEO_WEARABLE_HEADSET:
+                return "AUDIO_VIDEO_WEARABLE_HEADSET";
+            case BluetoothClass.Device.COMPUTER_DESKTOP:
+                return "COMPUTER_DESKTOP";
+            case BluetoothClass.Device.COMPUTER_HANDHELD_PC_PDA:
+                return "COMPUTER_HANDHELD_PC_PDA";
+            case BluetoothClass.Device.COMPUTER_LAPTOP:
+                return "COMPUTER_LAPTOP";
+            case BluetoothClass.Device.COMPUTER_PALM_SIZE_PC_PDA:
+                return "COMPUTER_PALM_SIZE_PC_PDA";
+            case BluetoothClass.Device.COMPUTER_SERVER:
+                return "COMPUTER_SERVER";
+            case BluetoothClass.Device.COMPUTER_UNCATEGORIZED:
+                return "COMPUTER_UNCATEGORIZED";
+            case BluetoothClass.Device.COMPUTER_WEARABLE:
+                return "COMPUTER_WEARABLE";
+            case BluetoothClass.Device.HEALTH_BLOOD_PRESSURE:
+                return "HEALTH_BLOOD_PRESSURE";
+            case BluetoothClass.Device.HEALTH_DATA_DISPLAY:
+                return "HEALTH_DATA_DISPLAY";
+            case BluetoothClass.Device.HEALTH_GLUCOSE:
+                return "HEALTH_GLUCOSE";
+            case BluetoothClass.Device.HEALTH_PULSE_OXIMETER:
+                return "HEALTH_PULSE_OXIMETER";
+            case BluetoothClass.Device.HEALTH_PULSE_RATE:
+                return "HEALTH_PULSE_RATE";
+            case BluetoothClass.Device.HEALTH_THERMOMETER:
+                return "HEALTH_THERMOMETER";
+            case BluetoothClass.Device.HEALTH_UNCATEGORIZED:
+                return "HEALTH_UNCATEGORIZED";
+            case BluetoothClass.Device.HEALTH_WEIGHING:
+                return "HEALTH_WEIGHING";
+            case BluetoothClass.Device.PHONE_CELLULAR:
+                return "PHONE_CELLULAR";
+            case BluetoothClass.Device.PHONE_CORDLESS:
+                return "PHONE_CORDLESS";
+            case BluetoothClass.Device.PHONE_ISDN:
+                return "PHONE_ISDN";
+            case BluetoothClass.Device.PHONE_MODEM_OR_GATEWAY:
+                return "PHONE_MODEM_OR_GATEWAY";
+            case BluetoothClass.Device.PHONE_SMART:
+                return "PHONE_SMART";
+            case BluetoothClass.Device.PHONE_UNCATEGORIZED:
+                return "PHONE_UNCATEGORIZED";
+            case BluetoothClass.Device.TOY_CONTROLLER:
+                return "TOY_CONTROLLER";
+            case BluetoothClass.Device.TOY_DOLL_ACTION_FIGURE:
+                return "TOY_DOLL_ACTION_FIGURE";
+            case BluetoothClass.Device.TOY_GAME:
+                return "TOY_GAME";
+            case BluetoothClass.Device.TOY_ROBOT:
+                return "TOY_ROBOT";
+            case BluetoothClass.Device.TOY_UNCATEGORIZED:
+                return "TOY_UNCATEGORIZED";
+            case BluetoothClass.Device.TOY_VEHICLE:
+                return "TOY_VEHICLE";
+            case BluetoothClass.Device.WEARABLE_GLASSES:
+                return "WEARABLE_GLASSES";
+            case BluetoothClass.Device.WEARABLE_HELMET:
+                return "WEARABLE_HELMET";
+            case BluetoothClass.Device.WEARABLE_JACKET:
+                return "WEARABLE_JACKET";
+            case BluetoothClass.Device.WEARABLE_PAGER:
+                return "WEARABLE_PAGER";
+            case BluetoothClass.Device.WEARABLE_UNCATEGORIZED:
+                return "WEARABLE_UNCATEGORIZED";
+            case BluetoothClass.Device.WEARABLE_WRIST_WATCH:
+                return "WEARABLE_WRIST_WATCH";
+            case BluetoothClass.Device.Major.UNCATEGORIZED:
+                return "UNCATEGORIZED";
+            default:
+                return "UNKNOWN" + Integer.toString(devClass);
+        }
+    }
 }

--- a/src/test/java/android/bluetooth/le/ScanSettings.java
+++ b/src/test/java/android/bluetooth/le/ScanSettings.java
@@ -1,0 +1,426 @@
+/*
+ * Copyright 2019 Fitbit, Inc. All rights reserved.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+/*
+ * Copyright (C) 2014 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package android.bluetooth.le;
+
+import android.bluetooth.BluetoothDevice;
+import android.os.Parcel;
+import android.os.Parcelable;
+
+/**
+ * Bluetooth LE scan settings are passed to {@link BluetoothLeScanner#startScan} to define the
+ * parameters for the scan.
+ *
+ * Why did we have to replicate this for the tests to pass?  The class loader couldn't load this
+ * class because it isn't present in whatever api jar is linked, however when I add it, then the
+ * tests can use it.
+ */
+public final class ScanSettings implements Parcelable {
+
+    /**
+     * A special Bluetooth LE scan mode. Applications using this scan mode will passively listen for
+     * other scan results without starting BLE scans themselves.
+     */
+    public static final int SCAN_MODE_OPPORTUNISTIC = -1;
+
+    /**
+     * Perform Bluetooth LE scan in low power mode. This is the default scan mode as it consumes the
+     * least power. This mode is enforced if the scanning application is not in foreground.
+     */
+    public static final int SCAN_MODE_LOW_POWER = 0;
+
+    /**
+     * Perform Bluetooth LE scan in balanced power mode. Scan results are returned at a rate that
+     * provides a good trade-off between scan frequency and power consumption.
+     */
+    public static final int SCAN_MODE_BALANCED = 1;
+
+    /**
+     * Scan using highest duty cycle. It's recommended to only use this mode when the application is
+     * running in the foreground.
+     */
+    public static final int SCAN_MODE_LOW_LATENCY = 2;
+
+    /**
+     * Trigger a callback for every Bluetooth advertisement found that matches the filter criteria.
+     * If no filter is active, all advertisement packets are reported.
+     */
+    public static final int CALLBACK_TYPE_ALL_MATCHES = 1;
+
+    /**
+     * A result callback is only triggered for the first advertisement packet received that matches
+     * the filter criteria.
+     */
+    public static final int CALLBACK_TYPE_FIRST_MATCH = 2;
+
+    /**
+     * Receive a callback when advertisements are no longer received from a device that has been
+     * previously reported by a first match callback.
+     */
+    public static final int CALLBACK_TYPE_MATCH_LOST = 4;
+
+
+    /**
+     * Determines how many advertisements to match per filter, as this is scarce hw resource
+     */
+    /**
+     * Match one advertisement per filter
+     */
+    public static final int MATCH_NUM_ONE_ADVERTISEMENT = 1;
+
+    /**
+     * Match few advertisement per filter, depends on current capability and availibility of
+     * the resources in hw
+     */
+    public static final int MATCH_NUM_FEW_ADVERTISEMENT = 2;
+
+    /**
+     * Match as many advertisement per filter as hw could allow, depends on current
+     * capability and availibility of the resources in hw
+     */
+    public static final int MATCH_NUM_MAX_ADVERTISEMENT = 3;
+
+
+    /**
+     * In Aggressive mode, hw will determine a match sooner even with feeble signal strength
+     * and few number of sightings/match in a duration.
+     */
+    public static final int MATCH_MODE_AGGRESSIVE = 1;
+
+    /**
+     * For sticky mode, higher threshold of signal strength and sightings is required
+     * before reporting by hw
+     */
+    public static final int MATCH_MODE_STICKY = 2;
+
+    /**
+     * Request full scan results which contain the device, rssi, advertising data, scan response
+     * as well as the scan timestamp.
+     *
+     */
+    public static final int SCAN_RESULT_TYPE_FULL = 0;
+
+    /**
+     * Request abbreviated scan results which contain the device, rssi and scan timestamp.
+     * <p>
+     * <b>Note:</b> It is possible for an application to get more scan results than it asked for, if
+     * there are multiple apps using this type.
+     *
+     */
+    public static final int SCAN_RESULT_TYPE_ABBREVIATED = 1;
+
+    /**
+     * Use all supported PHYs for scanning.
+     * This will check the controller capabilities, and start
+     * the scan on 1Mbit and LE Coded PHYs if supported, or on
+     * the 1Mbit PHY only.
+     */
+    public static final int PHY_LE_ALL_SUPPORTED = 255;
+
+    // Bluetooth LE scan mode.
+    private int mScanMode;
+
+    // Bluetooth LE scan callback type
+    private int mCallbackType;
+
+    // Bluetooth LE scan result type
+    private int mScanResultType;
+
+    // Time of delay for reporting the scan result
+    private long mReportDelayMillis;
+
+    private int mMatchMode;
+
+    private int mNumOfMatchesPerFilter;
+
+    // Include only legacy advertising results
+    private boolean mLegacy;
+
+    private int mPhy;
+
+    public int getScanMode() {
+        return mScanMode;
+    }
+
+    public int getCallbackType() {
+        return mCallbackType;
+    }
+
+    public int getScanResultType() {
+        return mScanResultType;
+    }
+
+    /**
+     * @hide
+     */
+    public int getMatchMode() {
+        return mMatchMode;
+    }
+
+    /**
+     * @hide
+     */
+    public int getNumOfMatches() {
+        return mNumOfMatchesPerFilter;
+    }
+
+    /**
+     * Returns whether only legacy advertisements will be returned.
+     * Legacy advertisements include advertisements as specified
+     * by the Bluetooth core specification 4.2 and below.
+     */
+    public boolean getLegacy() {
+        return mLegacy;
+    }
+
+    /**
+     * Returns the physical layer used during a scan.
+     */
+    public int getPhy() {
+        return mPhy;
+    }
+
+    /**
+     * Returns report delay timestamp based on the device clock.
+     */
+    public long getReportDelayMillis() {
+        return mReportDelayMillis;
+    }
+
+    private ScanSettings(int scanMode, int callbackType, int scanResultType,
+                         long reportDelayMillis, int matchMode,
+                         int numOfMatchesPerFilter, boolean legacy, int phy) {
+        mScanMode = scanMode;
+        mCallbackType = callbackType;
+        mScanResultType = scanResultType;
+        mReportDelayMillis = reportDelayMillis;
+        mNumOfMatchesPerFilter = numOfMatchesPerFilter;
+        mMatchMode = matchMode;
+        mLegacy = legacy;
+        mPhy = phy;
+    }
+
+    private ScanSettings(Parcel in) {
+        mScanMode = in.readInt();
+        mCallbackType = in.readInt();
+        mScanResultType = in.readInt();
+        mReportDelayMillis = in.readLong();
+        mMatchMode = in.readInt();
+        mNumOfMatchesPerFilter = in.readInt();
+        mLegacy = in.readInt() != 0;
+        mPhy = in.readInt();
+    }
+
+    @Override
+    public void writeToParcel(Parcel dest, int flags) {
+        dest.writeInt(mScanMode);
+        dest.writeInt(mCallbackType);
+        dest.writeInt(mScanResultType);
+        dest.writeLong(mReportDelayMillis);
+        dest.writeInt(mMatchMode);
+        dest.writeInt(mNumOfMatchesPerFilter);
+        dest.writeInt(mLegacy ? 1 : 0);
+        dest.writeInt(mPhy);
+    }
+
+    @Override
+    public int describeContents() {
+        return 0;
+    }
+
+    public static final Parcelable.Creator<ScanSettings> CREATOR =
+        new Creator<ScanSettings>() {
+            @Override
+            public ScanSettings[] newArray(int size) {
+                return new ScanSettings[size];
+            }
+
+            @Override
+            public ScanSettings createFromParcel(Parcel in) {
+                return new ScanSettings(in);
+            }
+        };
+
+    /**
+     * Builder for {@link ScanSettings}.
+     */
+    public static final class Builder {
+        private int mScanMode = SCAN_MODE_LOW_POWER;
+        private int mCallbackType = CALLBACK_TYPE_ALL_MATCHES;
+        private int mScanResultType = SCAN_RESULT_TYPE_FULL;
+        private long mReportDelayMillis = 0;
+        private int mMatchMode = MATCH_MODE_AGGRESSIVE;
+        private int mNumOfMatchesPerFilter = MATCH_NUM_MAX_ADVERTISEMENT;
+        private boolean mLegacy = true;
+        private int mPhy = PHY_LE_ALL_SUPPORTED;
+
+        /**
+         * Set scan mode for Bluetooth LE scan.
+         *
+         * @param scanMode The scan mode can be one of {@link ScanSettings#SCAN_MODE_LOW_POWER},
+         * {@link ScanSettings#SCAN_MODE_BALANCED} or {@link ScanSettings#SCAN_MODE_LOW_LATENCY}.
+         * @throws IllegalArgumentException If the {@code scanMode} is invalid.
+         */
+        public Builder setScanMode(int scanMode) {
+            if (scanMode < SCAN_MODE_OPPORTUNISTIC || scanMode > SCAN_MODE_LOW_LATENCY) {
+                throw new IllegalArgumentException("invalid scan mode " + scanMode);
+            }
+            mScanMode = scanMode;
+            return this;
+        }
+
+        /**
+         * Set callback type for Bluetooth LE scan.
+         *
+         * @param callbackType The callback type flags for the scan.
+         * @throws IllegalArgumentException If the {@code callbackType} is invalid.
+         */
+        public Builder setCallbackType(int callbackType) {
+
+            if (!isValidCallbackType(callbackType)) {
+                throw new IllegalArgumentException("invalid callback type - " + callbackType);
+            }
+            mCallbackType = callbackType;
+            return this;
+        }
+
+        // Returns true if the callbackType is valid.
+        private boolean isValidCallbackType(int callbackType) {
+            if (callbackType == CALLBACK_TYPE_ALL_MATCHES
+                || callbackType == CALLBACK_TYPE_FIRST_MATCH
+                || callbackType == CALLBACK_TYPE_MATCH_LOST) {
+                return true;
+            }
+            return callbackType == (CALLBACK_TYPE_FIRST_MATCH | CALLBACK_TYPE_MATCH_LOST);
+        }
+
+        /**
+         * Set scan result type for Bluetooth LE scan.
+         *
+         * @param scanResultType Type for scan result, could be either {@link
+         * ScanSettings#SCAN_RESULT_TYPE_FULL} or {@link ScanSettings#SCAN_RESULT_TYPE_ABBREVIATED}.
+         * @throws IllegalArgumentException If the {@code scanResultType} is invalid.
+         */
+
+        public Builder setScanResultType(int scanResultType) {
+            if (scanResultType < SCAN_RESULT_TYPE_FULL
+                || scanResultType > SCAN_RESULT_TYPE_ABBREVIATED) {
+                throw new IllegalArgumentException(
+                    "invalid scanResultType - " + scanResultType);
+            }
+            mScanResultType = scanResultType;
+            return this;
+        }
+
+        /**
+         * Set report delay timestamp for Bluetooth LE scan.
+         *
+         * @param reportDelayMillis Delay of report in milliseconds. Set to 0 to be notified of
+         * results immediately. Values &gt; 0 causes the scan results to be queued up and delivered
+         * after the requested delay or when the internal buffers fill up.
+         * @throws IllegalArgumentException If {@code reportDelayMillis} &lt; 0.
+         */
+        public Builder setReportDelay(long reportDelayMillis) {
+            if (reportDelayMillis < 0) {
+                throw new IllegalArgumentException("reportDelay must be > 0");
+            }
+            mReportDelayMillis = reportDelayMillis;
+            return this;
+        }
+
+        /**
+         * Set the number of matches for Bluetooth LE scan filters hardware match
+         *
+         * @param numOfMatches The num of matches can be one of
+         * {@link ScanSettings#MATCH_NUM_ONE_ADVERTISEMENT}
+         * or {@link ScanSettings#MATCH_NUM_FEW_ADVERTISEMENT} or {@link
+         * ScanSettings#MATCH_NUM_MAX_ADVERTISEMENT}
+         * @throws IllegalArgumentException If the {@code matchMode} is invalid.
+         */
+        public Builder setNumOfMatches(int numOfMatches) {
+            if (numOfMatches < MATCH_NUM_ONE_ADVERTISEMENT
+                || numOfMatches > MATCH_NUM_MAX_ADVERTISEMENT) {
+                throw new IllegalArgumentException("invalid numOfMatches " + numOfMatches);
+            }
+            mNumOfMatchesPerFilter = numOfMatches;
+            return this;
+        }
+
+        /**
+         * Set match mode for Bluetooth LE scan filters hardware match
+         *
+         * @param matchMode The match mode can be one of {@link ScanSettings#MATCH_MODE_AGGRESSIVE}
+         * or {@link ScanSettings#MATCH_MODE_STICKY}
+         * @throws IllegalArgumentException If the {@code matchMode} is invalid.
+         */
+        public Builder setMatchMode(int matchMode) {
+            if (matchMode < MATCH_MODE_AGGRESSIVE
+                || matchMode > MATCH_MODE_STICKY) {
+                throw new IllegalArgumentException("invalid matchMode " + matchMode);
+            }
+            mMatchMode = matchMode;
+            return this;
+        }
+
+        /**
+         * Set whether only legacy advertisments should be returned in scan results.
+         * Legacy advertisements include advertisements as specified by the
+         * Bluetooth core specification 4.2 and below. This is true by default
+         * for compatibility with older apps.
+         *
+         * @param legacy true if only legacy advertisements will be returned
+         */
+        public Builder setLegacy(boolean legacy) {
+            mLegacy = legacy;
+            return this;
+        }
+
+        /**
+         * Set the Physical Layer to use during this scan.
+         * This is used only if {@link ScanSettings.Builder#setLegacy}
+         * is set to false.
+         * {@link android.bluetooth.BluetoothAdapter#isLeCodedPhySupported}
+         * may be used to check whether LE Coded phy is supported by calling
+         * {@link android.bluetooth.BluetoothAdapter#isLeCodedPhySupported}.
+         * Selecting an unsupported phy will result in failure to start scan.
+         *
+         * @param phy Can be one of {@link BluetoothDevice#PHY_LE_1M}, {@link
+         * BluetoothDevice#PHY_LE_CODED} or {@link ScanSettings#PHY_LE_ALL_SUPPORTED}
+         */
+        public Builder setPhy(int phy) {
+            mPhy = phy;
+            return this;
+        }
+
+        /**
+         * Build {@link ScanSettings}.
+         */
+        public ScanSettings build() {
+            return new ScanSettings(mScanMode, mCallbackType, mScanResultType,
+                mReportDelayMillis, mMatchMode,
+                mNumOfMatchesPerFilter, mLegacy, mPhy);
+        }
+    }
+}
+

--- a/src/test/java/com/fitbit/bluetooth/fbgatt/AlwaysConnectedScannerTest.java
+++ b/src/test/java/com/fitbit/bluetooth/fbgatt/AlwaysConnectedScannerTest.java
@@ -1,0 +1,417 @@
+/*
+ * Copyright 2019 Fitbit, Inc. All rights reserved.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+package com.fitbit.bluetooth.fbgatt;
+
+import com.fitbit.bluetooth.fbgatt.tx.GattConnectTransaction;
+
+import android.bluetooth.le.ScanFilter;
+import android.content.Context;
+import android.content.Intent;
+import android.os.Handler;
+import android.os.Looper;
+import android.os.ParcelUuid;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.mockito.stubbing.Answer;
+
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.Timer;
+import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+import static junit.framework.Assert.assertFalse;
+import static junit.framework.TestCase.assertTrue;
+import static junit.framework.TestCase.fail;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Will test the behavior of the always connected scanner with the mock lollipop scanner
+ */
+public class AlwaysConnectedScannerTest {
+
+    private static MockLollipopScanner mockScanner;
+    private FitbitGatt gatt;
+    private Context mockContext;
+    private PeripheralScanner peripheralScanner;
+    private AlwaysConnectedScanner alwaysConnectedScanner;
+    private Handler mockHandler;
+    private ScheduledExecutorService singleThreadExecutor = Executors.newSingleThreadScheduledExecutor();
+    private Answer<Boolean> handlerPostAnswer = invocation -> {
+        Long delay = 0L;
+        if (invocation.getArguments().length > 1) {
+            delay = invocation.getArgument(1);
+        }
+        Runnable msg = invocation.getArgument(0);
+        if (msg != null) {
+            singleThreadExecutor.schedule(msg, delay, TimeUnit.MILLISECONDS);
+        }
+        return true;
+    };
+
+    @BeforeClass
+    public static void beforeClass() {
+        mockScanner = MockLollipopScanner.BluetoothAdapter.getBluetoothLeScanner();
+    }
+
+    @Before
+    public void before(){
+        Looper mockMainThreadLooper = mock(Looper.class);
+        Thread mockMainThread = mock(Thread.class);
+        when(mockMainThread.getName()).thenReturn("Irvin's mock thread");
+        when(mockMainThreadLooper.getThread()).thenReturn(mockMainThread);
+        mockContext = mock(Context.class);
+        when(mockContext.getApplicationContext()).thenReturn(mockContext);
+        when(mockContext.registerReceiver(any(), any())).thenReturn(new Intent("some custom action"));
+        when(mockContext.getMainLooper()).thenReturn(mockMainThreadLooper);
+        mockHandler = mock(Handler.class);
+        doAnswer(handlerPostAnswer).when(mockHandler).post(any(Runnable.class));
+        doAnswer(handlerPostAnswer).when(mockHandler).postDelayed(any(Runnable.class), anyLong());
+        when(mockHandler.getLooper()).thenReturn(mockMainThreadLooper);
+        gatt = FitbitGatt.getInstance();
+        gatt.start(mockContext);
+        gatt.setScannerMockMode(true);
+        MockLollipopScanner.BluetoothAdapter.turnBluetoothOn();
+        alwaysConnectedScanner = gatt.getAlwaysConnectedScanner();
+        alwaysConnectedScanner.setHandler(mockHandler);
+        peripheralScanner = gatt.getPeripheralScanner();
+        if(peripheralScanner == null) {
+            fail("No peripheral scanner, must not have started");
+            return;
+        }
+        peripheralScanner.injectMockScanner(mockScanner);
+        peripheralScanner.setHandler(mockHandler);
+        peripheralScanner.cancelScan(mockContext);
+        peripheralScanner.cancelPeriodicalScan(mockContext);
+        peripheralScanner.cancelHighPriorityScan(mockContext);
+        peripheralScanner.cancelPendingIntentBasedBackgroundScan();
+        alwaysConnectedScanner.stop(mockContext);
+        alwaysConnectedScanner.restartCanStart();
+    }
+
+    @After
+    public void after(){
+        // dunno yet
+    }
+
+    /**
+     * Will test to make sure that we can't do ad-hoc scanning while the scanner is already engaged
+     */
+
+    @Test
+    public void testTryToScanAlwaysConnectedOnShouldNotStart(){
+        // generic scan filter
+        ScanFilter filter = new ScanFilter.Builder().build();
+        alwaysConnectedScanner.setNumberOfExpectedDevices(1);
+        alwaysConnectedScanner.setShouldKeepLooking(false);
+        alwaysConnectedScanner.addScanFilter(mockContext, filter);
+        assertTrue(alwaysConnectedScanner.start(mockContext));
+        // there is a single set of filters for all scanners
+        assertFalse(gatt.startHighPriorityScan(mockContext));
+    }
+
+    @Test
+    public void testTryToScanAlwaysConnectedButRegularScannerRunning(){
+        // generic scan filter
+        ScanFilter filter = new ScanFilter.Builder().build();
+        alwaysConnectedScanner.setNumberOfExpectedDevices(1);
+        alwaysConnectedScanner.setShouldKeepLooking(false);
+        alwaysConnectedScanner.addScanFilter(mockContext, filter);
+        // there is a single set of filters for all scanners
+        peripheralScanner.isScanning.set(true);
+        assertFalse(alwaysConnectedScanner.start(mockContext));
+    }
+
+    @Test
+    public void testTryToScanAwaysConnectedButPeriodicalScannerRunning(){
+        // generic scan filter
+        ScanFilter filter = new ScanFilter.Builder().build();
+        alwaysConnectedScanner.setNumberOfExpectedDevices(1);
+        alwaysConnectedScanner.setShouldKeepLooking(false);
+        alwaysConnectedScanner.addScanFilter(mockContext, filter);
+        // there is a single set of filters for all scanners
+        peripheralScanner.periodicalScanEnabled.set(true);
+        assertFalse(alwaysConnectedScanner.start(mockContext));
+    }
+
+    @Test
+    public void testAlwaysConnectedFindOneDeviceThenStop() throws InterruptedException {
+        // generic scan filter
+        ScanFilter filter = new ScanFilter.Builder().build();
+        alwaysConnectedScanner.setNumberOfExpectedDevices(1);
+        alwaysConnectedScanner.setShouldKeepLooking(false);
+        alwaysConnectedScanner.addScanFilter(mockContext, filter);
+        CountDownLatch cdl = new CountDownLatch(1);
+        AlwaysConnectedScannerListener callback = new AlwaysConnectedScannerListener() {
+            @Override
+            public void onPeripheralConnected(GattConnection connection) {
+                cdl.countDown();
+                assertFalse(peripheralScanner.isScanning());
+                assertFalse(peripheralScanner.isPeriodicalScanEnabled());
+                assertFalse(peripheralScanner.isPendingIntentScanning());
+            }
+
+            @Override
+            public void onPeripheralConnectionError(TransactionResult result) {
+
+            }
+        };
+        alwaysConnectedScanner.registerAlwaysConnectedScannerListener(callback);
+        alwaysConnectedScanner.start(mockContext);
+        mockHandler.postDelayed(() -> {
+            GattConnection connection = new GattConnection(mock(FitbitBluetoothDevice.class), mockContext.getMainLooper());
+            connection.setMockMode(true);
+            connection.setState(GattState.CONNECTED);
+            alwaysConnectedScanner.onBluetoothPeripheralDiscovered(connection);
+        }, 1000);
+        boolean result = cdl.await(5, TimeUnit.SECONDS);
+        if(!result) {
+            alwaysConnectedScanner.unregisterAlwaysConnectedScannerListener(callback);
+            fail("Test timed out");
+        } else {
+            alwaysConnectedScanner.unregisterAlwaysConnectedScannerListener(callback);
+        }
+    }
+
+    @Test
+    public void testPriorityScanAfterStartOnlyRunsForSetScanTime() throws InterruptedException{
+        // generic scan filter
+        ScanFilter filter = new ScanFilter.Builder().build();
+        alwaysConnectedScanner.setNumberOfExpectedDevices(1);
+        alwaysConnectedScanner.setShouldKeepLooking(false);
+        alwaysConnectedScanner.addScanFilter(mockContext, filter);
+        CountDownLatch cdl = new CountDownLatch(3);
+        long startTime = new Date().getTime();
+        NoOpFitbitGattCallback callback = new NoOpFitbitGattCallback() {
+            @Override
+            public void onScanStarted() {
+                cdl.countDown();
+            }
+
+            @Override
+            public void onScanStopped() {
+                if(cdl.getCount() == 1) {
+                    // should be called within PeripheralScanner.SCAN_DURATION
+                    // and high priority scan should not be continuing
+                    long currentTime = new Date().getTime();
+                    long diff = currentTime - startTime;
+                    assertTrue(diff <= PeripheralScanner.SCAN_DURATION);
+                    assertFalse(peripheralScanner.isScanning());
+                    cdl.countDown();
+                } else {
+                    cdl.countDown();
+                }
+            }
+        };
+        gatt.registerGattEventListener(callback);
+        alwaysConnectedScanner.start(mockContext);
+        boolean didStart = alwaysConnectedScanner.startHighPriorityScan(mockContext);
+        if(!didStart) {
+            gatt.unregisterGattEventListener(callback);
+            fail("Always connected scanner didn't start high priority scan");
+            return;
+        }
+        boolean result = cdl.await(5, TimeUnit.SECONDS);
+        if(!result) {
+            gatt.unregisterGattEventListener(callback);
+            fail("Test timed out");
+        } else {
+            gatt.unregisterGattEventListener(callback);
+        }
+    }
+
+    @Test
+    public void expectedZeroDevicesShouldNotStopScanIfContinueEnabled() throws InterruptedException {
+        // generic scan filter
+        ScanFilter filter = new ScanFilter.Builder().build();
+        alwaysConnectedScanner.setNumberOfExpectedDevices(0);
+        alwaysConnectedScanner.setShouldKeepLooking(false);
+        alwaysConnectedScanner.addScanFilter(mockContext, filter);
+        assertTrue(alwaysConnectedScanner.start(mockContext));
+        // there is a single set of filters for all scanners
+        CountDownLatch cdl = new CountDownLatch(1);
+        AlwaysConnectedScannerListener callback = new AlwaysConnectedScannerListener() {
+            @Override
+            public void onPeripheralConnected(GattConnection connection) {
+                cdl.countDown();
+                assertTrue(peripheralScanner.isPeriodicalScanEnabled());
+            }
+
+            @Override
+            public void onPeripheralConnectionError(TransactionResult result) {
+
+            }
+        };
+        alwaysConnectedScanner.registerAlwaysConnectedScannerListener(callback);
+        mockHandler.postDelayed(() -> {
+            GattConnection connection = new GattConnection(mock(FitbitBluetoothDevice.class), mockContext.getMainLooper());
+            connection.setMockMode(true);
+            connection.setState(GattState.CONNECTED);
+            alwaysConnectedScanner.onBluetoothPeripheralDiscovered(connection);
+        }, 1000);
+        boolean result = cdl.await(5, TimeUnit.SECONDS);
+        if(!result) {
+            alwaysConnectedScanner.unregisterAlwaysConnectedScannerListener(callback);
+            fail("Test timed out");
+        } else {
+            alwaysConnectedScanner.unregisterAlwaysConnectedScannerListener(callback);
+        }
+    }
+
+    @Test
+    public void expectedOneDevicesShouldStopScanIfContinueDisabled() throws InterruptedException {
+        // generic scan filter
+        ScanFilter filter = new ScanFilter.Builder().build();
+        alwaysConnectedScanner.setNumberOfExpectedDevices(1);
+        alwaysConnectedScanner.setShouldKeepLooking(false);
+        alwaysConnectedScanner.addScanFilter(mockContext, filter);
+        assertTrue(alwaysConnectedScanner.start(mockContext));
+        // there is a single set of filters for all scanners
+        CountDownLatch cdl = new CountDownLatch(1);
+        AlwaysConnectedScannerListener callback = new AlwaysConnectedScannerListener() {
+            @Override
+            public void onPeripheralConnected(GattConnection connection) {
+                assertFalse(peripheralScanner.isPeriodicalScanEnabled());
+                cdl.countDown();
+            }
+
+            @Override
+            public void onPeripheralConnectionError(TransactionResult result) {
+
+            }
+        };
+        alwaysConnectedScanner.registerAlwaysConnectedScannerListener(callback);
+        mockHandler.postDelayed(() -> {
+            GattConnection connection = new GattConnection(mock(FitbitBluetoothDevice.class), mockContext.getMainLooper());
+            connection.setMockMode(true);
+            connection.setState(GattState.CONNECTED);
+            alwaysConnectedScanner.onBluetoothPeripheralDiscovered(connection);
+        }, 1000);
+        boolean result = cdl.await(5, TimeUnit.SECONDS);
+        if(!result) {
+            alwaysConnectedScanner.unregisterAlwaysConnectedScannerListener(callback);
+            fail("Test timed out");
+        } else {
+            alwaysConnectedScanner.unregisterAlwaysConnectedScannerListener(callback);
+        }
+    }
+
+    @Test
+    public void expectedOneDevicesShouldNotStopScanIfContinueEnabled() throws InterruptedException {
+        // generic scan filter
+        ScanFilter filter = new ScanFilter.Builder().build();
+        alwaysConnectedScanner.setNumberOfExpectedDevices(1);
+        alwaysConnectedScanner.setShouldKeepLooking(false);
+        alwaysConnectedScanner.addScanFilter(mockContext, filter);
+        assertTrue(alwaysConnectedScanner.start(mockContext));
+        // there is a single set of filters for all scanners
+        CountDownLatch cdl = new CountDownLatch(1);
+        AlwaysConnectedScannerListener callback = new AlwaysConnectedScannerListener() {
+            @Override
+            public void onPeripheralConnected(GattConnection connection) {
+                cdl.countDown();
+                assertTrue(peripheralScanner.isPeriodicalScanEnabled());
+            }
+
+            @Override
+            public void onPeripheralConnectionError(TransactionResult result) {
+
+            }
+        };
+        alwaysConnectedScanner.registerAlwaysConnectedScannerListener(callback);
+        mockHandler.postDelayed(() -> {
+            GattConnection connection = new GattConnection(mock(FitbitBluetoothDevice.class), mockContext.getMainLooper());
+            connection.setMockMode(true);
+            connection.setState(GattState.CONNECTED);
+            alwaysConnectedScanner.onBluetoothPeripheralDiscovered(connection);
+        }, 1000);
+        boolean result = cdl.await(5, TimeUnit.SECONDS);
+        if(!result) {
+            alwaysConnectedScanner.unregisterAlwaysConnectedScannerListener(callback);
+            fail("Test timed out");
+        } else {
+            alwaysConnectedScanner.unregisterAlwaysConnectedScannerListener(callback);
+        }
+    }
+
+    /**
+     * Since its likely that we will continue to use the callback to manage various test verifications
+     * as an efficiency we will create a no op class so that we don't have to constantly re-implement
+     * these methods.
+     */
+
+    private class NoOpFitbitGattCallback implements FitbitGatt.FitbitGattCallback {
+
+        @Override
+        public void onBluetoothPeripheralDiscovered(GattConnection connection) {
+
+        }
+
+        @Override
+        public void onBluetoothPeripheralDisconnected(GattConnection connection) {
+
+        }
+
+        @Override
+        public void onFitbitGattReady() {
+
+        }
+
+        @Override
+        public void onScanStarted() {
+
+        }
+
+        @Override
+        public void onScanStopped() {
+
+        }
+
+        @Override
+        public void onPendingIntentScanStopped() {
+
+        }
+
+        @Override
+        public void onPendingIntentScanStarted() {
+
+        }
+
+        @Override
+        public void onBluetoothOff() {
+
+        }
+
+        @Override
+        public void onBluetoothOn() {
+
+        }
+
+        @Override
+        public void onBluetoothTurningOn() {
+
+        }
+
+        @Override
+        public void onBluetoothTurningOff() {
+
+        }
+    }
+}

--- a/src/test/java/com/fitbit/bluetooth/fbgatt/GattConnectionTests.java
+++ b/src/test/java/com/fitbit/bluetooth/fbgatt/GattConnectionTests.java
@@ -16,8 +16,8 @@ import android.bluetooth.BluetoothDevice;
 import android.bluetooth.BluetoothGatt;
 import android.bluetooth.BluetoothGattServer;
 import android.os.Looper;
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import com.fitbit.bluetooth.fbgatt.btcopies.BluetoothGattCharacteristicCopy;
 import com.fitbit.bluetooth.fbgatt.btcopies.BluetoothGattDescriptorCopy;

--- a/src/test/java/com/fitbit/bluetooth/fbgatt/GattRegisterEventListenerTest.java
+++ b/src/test/java/com/fitbit/bluetooth/fbgatt/GattRegisterEventListenerTest.java
@@ -12,7 +12,7 @@ import android.bluetooth.BluetoothDevice;
 import android.content.Context;
 import android.os.Handler;
 import android.os.Looper;
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import org.junit.Before;
 import org.junit.Test;

--- a/src/test/java/com/fitbit/bluetooth/fbgatt/MockLollipopScanner.java
+++ b/src/test/java/com/fitbit/bluetooth/fbgatt/MockLollipopScanner.java
@@ -1,0 +1,781 @@
+/*
+ * Copyright 2019 Fitbit, Inc. All rights reserved.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+/*
+ * Copyright (C) 2014 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.fitbit.bluetooth.fbgatt;
+
+import android.app.PendingIntent;
+import android.bluetooth.BluetoothGatt;
+import android.bluetooth.le.ScanCallback;
+import android.bluetooth.le.ScanFilter;
+import android.bluetooth.le.ScanResult;
+import android.bluetooth.le.ScanSettings;
+import android.os.Handler;
+import android.os.Looper;
+import android.os.Parcel;
+import android.os.Parcelable;
+import android.os.SystemClock;
+import android.os.WorkSource;
+import android.util.Log;
+
+import org.mockito.stubbing.Answer;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import timber.log.Timber;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * This is not fitbit code, this is designed to mock, in as close fidelity as possible the google
+ * android scanner from Android Pie.  This still isn't flawless, but it should allow us to test
+ * some of the harder scenarios to unit test by providing a mock adapter and a mock scanner that
+ * is injectable from a mockito mock of the adapter, or just mocking the scanner if possible.
+ *
+ * This is a work-in-progress : 2019-07-08
+ */
+
+public class MockLollipopScanner implements ScannerInterface {
+
+    private static final String TAG = "MockLollipopScanner";
+    private static final boolean DBG = true;
+    private static final boolean VDBG = false;
+
+    private Handler mockHandler;
+
+    private static ScheduledExecutorService singleThreadExecutor = Executors.newSingleThreadScheduledExecutor();
+    private Answer<Boolean> handlerPostAnswer = invocation -> {
+        Long delay = 0L;
+        if (invocation.getArguments().length > 1) {
+            delay = invocation.getArgument(1);
+        }
+        Runnable msg = invocation.getArgument(0);
+        if (msg != null) {
+            singleThreadExecutor.schedule(msg, delay, TimeUnit.MILLISECONDS);
+        }
+        return true;
+    };
+
+    public static class BluetoothAdapter {
+        static boolean adapterOn = false;
+        static IBluetoothGatt gatt = new IBluetoothGatt();
+
+        public static boolean getAdapterState() {
+            return adapterOn;
+        }
+
+        public static void turnBluetoothOff() {
+            adapterOn = false;
+        }
+
+        public static void turnBluetoothOn() {
+            adapterOn = true;
+        }
+
+        public static MockLollipopScanner getBluetoothLeScanner() {
+            return new MockLollipopScanner();
+        }
+
+        public static IBluetoothGatt getGatt() {
+            return gatt;
+        }
+
+    }
+
+    public static final class ResultStorageDescriptor implements Parcelable {
+        private int mType;
+        private int mOffset;
+        private int mLength;
+
+        public int getType() {
+            return mType;
+        }
+
+        public int getOffset() {
+            return mOffset;
+        }
+
+        public int getLength() {
+            return mLength;
+        }
+
+        /**
+         * Constructor of {@link ResultStorageDescriptor}
+         *
+         * @param type   Type of the data.
+         * @param offset Offset from start of the advertise packet payload.
+         * @param length Byte length of the data
+         */
+        public ResultStorageDescriptor(int type, int offset, int length) {
+            mType = type;
+            mOffset = offset;
+            mLength = length;
+        }
+
+        @Override
+        public int describeContents() {
+            return 0;
+        }
+
+        @Override
+        public void writeToParcel(Parcel dest, int flags) {
+            dest.writeInt(mType);
+            dest.writeInt(mOffset);
+            dest.writeInt(mLength);
+        }
+
+        private ResultStorageDescriptor(Parcel in) {
+            ReadFromParcel(in);
+        }
+
+        private void ReadFromParcel(Parcel in) {
+            mType = in.readInt();
+            mOffset = in.readInt();
+            mLength = in.readInt();
+        }
+
+        public static final Parcelable.Creator<ResultStorageDescriptor> CREATOR =
+            new Creator<ResultStorageDescriptor>() {
+                @Override
+                public ResultStorageDescriptor createFromParcel(Parcel source) {
+                    return new ResultStorageDescriptor(source);
+                }
+
+                @Override
+                public ResultStorageDescriptor[] newArray(int size) {
+                    return new ResultStorageDescriptor[size];
+                }
+            };
+    }
+
+    /**
+     * Extra containing a list of ScanResults. It can have one or more results if there was no
+     * error. In case of error, {@link #EXTRA_ERROR_CODE} will contain the error code and this
+     * extra will not be available.
+     */
+    public static final String EXTRA_LIST_SCAN_RESULT =
+        "android.bluetooth.le.extra.LIST_SCAN_RESULT";
+
+    /**
+     * Optional extra indicating the error code, if any. The error code will be one of the
+     * SCAN_FAILED_* codes in {@link ScanCallback}.
+     */
+    public static final String EXTRA_ERROR_CODE = "android.bluetooth.le.extra.ERROR_CODE";
+
+    /**
+     * Optional extra indicating the callback type, which will be one of
+     * CALLBACK_TYPE_* constants in {@link ScanSettings}.
+     *
+     * @see ScanCallback#onScanResult(int, ScanResult)
+     */
+    public static final String EXTRA_CALLBACK_TYPE = "android.bluetooth.le.extra.CALLBACK_TYPE";
+
+    private Handler mHandler;
+
+    private final Map<ScanCallback, BleScanCallbackWrapper> mLeScanClients;
+
+    /**
+     * Use {@link BluetoothAdapter#getBluetoothLeScanner()} instead.
+     *
+     */
+    public MockLollipopScanner() {
+        Looper mockMainThreadLooper = mock(Looper.class);
+        Thread mockMainThread = mock(Thread.class);
+        when(mockMainThread.getName()).thenReturn("Irvin's mock thread");
+        when(mockMainThreadLooper.getThread()).thenReturn(mockMainThread);
+        mockHandler = mock(Handler.class);
+        doAnswer(handlerPostAnswer).when(mockHandler).post(any(Runnable.class));
+        doAnswer(handlerPostAnswer).when(mockHandler).postDelayed(any(Runnable.class), anyLong());
+        when(mockHandler.getLooper()).thenReturn(mockMainThreadLooper);
+        mHandler = mockHandler;
+        mLeScanClients = new HashMap<ScanCallback, BleScanCallbackWrapper>();
+    }
+
+    /**
+     * Start Bluetooth LE scan with default parameters and no filters. The scan results will be
+     * delivered through {@code callback}. For unfiltered scans, scanning is stopped on screen
+     * off to save power. Scanning is resumed when screen is turned on again. To avoid this, use
+     * {@link #startScan(List, ScanSettings, ScanCallback)} with desired {@link ScanFilter}.
+     * <p>
+     * An app must hold
+     * {@link android.Manifest.permission#ACCESS_COARSE_LOCATION ACCESS_COARSE_LOCATION} or
+     * {@link android.Manifest.permission#ACCESS_FINE_LOCATION ACCESS_FINE_LOCATION} permission
+     * in order to get results.
+     *
+     * @param callback Callback used to deliver scan results.
+     */
+    @Override
+    public void startScan(final ScanCallback callback) {
+        startScan(null, new ScanSettings.Builder().build(), callback);
+    }
+
+    /**
+     * Start Bluetooth LE scan. The scan results will be delivered through {@code callback}.
+     * For unfiltered scans, scanning is stopped on screen off to save power. Scanning is
+     * resumed when screen is turned on again. To avoid this, do filetered scanning by
+     * using proper {@link ScanFilter}.
+     * <p>
+     * An app must hold
+     * {@link android.Manifest.permission#ACCESS_COARSE_LOCATION ACCESS_COARSE_LOCATION} or
+     * {@link android.Manifest.permission#ACCESS_FINE_LOCATION ACCESS_FINE_LOCATION} permission
+     * in order to get results.
+     *
+     * @param filters  {@link ScanFilter}s for finding exact BLE devices.
+     * @param settings Settings for the scan.
+     * @param callback Callback used to deliver scan results.
+     */
+    @Override
+    public void startScan(List<ScanFilter> filters, ScanSettings settings,
+                          final ScanCallback callback) {
+        startScan(filters, settings, null, callback, /*callbackIntent=*/ null, null);
+    }
+
+    /**
+     * Start Bluetooth LE scan using a {@link PendingIntent}. The scan results will be delivered via
+     * the PendingIntent. Use this method of scanning if your process is not always running and it
+     * should be started when scan results are available.
+     * <p>
+     * An app must hold
+     * {@link android.Manifest.permission#ACCESS_COARSE_LOCATION ACCESS_COARSE_LOCATION} or
+     * {@link android.Manifest.permission#ACCESS_FINE_LOCATION ACCESS_FINE_LOCATION} permission
+     * in order to get results.
+     * <p>
+     * When the PendingIntent is delivered, the Intent passed to the receiver or activity
+     * will contain one or more of the extras {@link #EXTRA_CALLBACK_TYPE},
+     * {@link #EXTRA_ERROR_CODE} and {@link #EXTRA_LIST_SCAN_RESULT} to indicate the result of
+     * the scan.
+     *
+     * @param filters        Optional list of ScanFilters for finding exact BLE devices.
+     * @param settings       Optional settings for the scan.
+     * @param callbackIntent The PendingIntent to deliver the result to.
+     * @return Returns 0 for success or an error code from {@link ScanCallback} if the scan request
+     * could not be sent.
+     * @see #stopScan(PendingIntent)
+     */
+
+    public int startScan(@Nullable List<ScanFilter> filters, @Nullable ScanSettings settings,
+                         @NonNull PendingIntent callbackIntent) {
+        return startScan(filters,
+            settings != null ? settings : new ScanSettings.Builder().build(),
+            null, null, callbackIntent, null);
+    }
+
+    private int startScan(List<ScanFilter> filters, ScanSettings settings,
+                          final WorkSource workSource, final ScanCallback callback,
+                          final PendingIntent callbackIntent,
+                          List<List<ResultStorageDescriptor>> resultStorages) {
+        if (!BluetoothAdapter.getAdapterState()) {
+            throw new IllegalStateException("Bluetooth off");
+        }
+        if (callback == null && callbackIntent == null) {
+            throw new IllegalArgumentException("callback is null");
+        }
+        if (settings == null) {
+            throw new IllegalArgumentException("settings is null");
+        }
+        synchronized (mLeScanClients) {
+            if (callback != null && mLeScanClients.containsKey(callback)) {
+                return postCallbackErrorOrReturn(callback,
+                    ScanCallback.SCAN_FAILED_ALREADY_STARTED);
+            }
+            IBluetoothGatt gatt = new IBluetoothGatt();
+            if (!isSettingsConfigAllowedForScan(settings)) {
+                return postCallbackErrorOrReturn(callback,
+                    ScanCallback.SCAN_FAILED_FEATURE_UNSUPPORTED);
+            }
+            if (!isHardwareResourcesAvailableForScan(settings)) {
+                Timber.e("Actually scan failed out of hardware resources");
+                return postCallbackErrorOrReturn(callback,
+                    5);
+            }
+            if (!isSettingsAndFilterComboAllowed(settings, filters)) {
+                return postCallbackErrorOrReturn(callback,
+                    ScanCallback.SCAN_FAILED_FEATURE_UNSUPPORTED);
+            }
+            if (callback != null) {
+                BleScanCallbackWrapper wrapper = new BleScanCallbackWrapper(gatt, filters,
+                    settings, workSource, callback, resultStorages);
+                wrapper.startRegistration();
+            } else {
+                gatt.startScanForIntent(callbackIntent, settings, filters,
+                    "com.fitbit.bluetooth.fbgatt");
+            }
+        }
+        return 0;
+    }
+
+    /**
+     * Stops an ongoing Bluetooth LE scan.
+     *
+     * @param callback
+     */
+
+    public void stopScan(ScanCallback callback) {
+        if (!BluetoothAdapter.getAdapterState()) {
+            throw new IllegalStateException("Bluetooth off");
+        }
+        synchronized (mLeScanClients) {
+            BleScanCallbackWrapper wrapper = mLeScanClients.remove(callback);
+            if (wrapper == null) {
+                if (DBG) Log.d(TAG, "could not find callback wrapper");
+                return;
+            }
+            wrapper.stopLeScan();
+        }
+    }
+
+    /**
+     * Stops an ongoing Bluetooth LE scan started using a PendingIntent.
+     *
+     * @param callbackIntent The PendingIntent that was used to start the scan.
+     * @see #startScan(List, ScanSettings, PendingIntent)
+     */
+
+    public void stopScan(PendingIntent callbackIntent) {
+        if (!BluetoothAdapter.getAdapterState()) {
+            throw new IllegalStateException("Bluetooth off");
+        }
+        IBluetoothGatt gatt = BluetoothAdapter.getGatt();
+        gatt.stopScanForIntent(callbackIntent, "com.fitbit.bluetooth.fbgatt");
+    }
+
+    /**
+     * Flush pending batch scan results stored in Bluetooth controller. This will return Bluetooth
+     * LE scan results batched on bluetooth controller. Returns immediately, batch scan results data
+     * will be delivered through the {@code callback}.
+     *
+     * @param callback Callback of the Bluetooth LE Scan, it has to be the same instance as the one
+     *                 used to start scan.
+     */
+    public void flushPendingScanResults(ScanCallback callback) {
+        if (!BluetoothAdapter.getAdapterState()) {
+            throw new IllegalStateException("Bluetooth off");
+        }
+        if (callback == null) {
+            throw new IllegalArgumentException("callback cannot be null!");
+        }
+        synchronized (mLeScanClients) {
+            BleScanCallbackWrapper wrapper = mLeScanClients.get(callback);
+            if (wrapper == null) {
+                return;
+            }
+            wrapper.flushPendingBatchResults();
+        }
+    }
+
+    @Override
+    public boolean isBluetoothEnabled() {
+        return BluetoothAdapter.getAdapterState();
+    }
+
+
+    /**
+     * Cleans up scan clients. Should be called when bluetooth is down.
+     */
+    public void cleanup() {
+        mLeScanClients.clear();
+    }
+
+    private static class IBluetoothGatt {
+        private static final long TIME_BETWEEN_RESULTS = 1000;
+        HashMap<BleScanCallbackWrapper, WorkSource> scanners = new HashMap<>();
+        HashMap<Integer, ScanState> startedScanners = new HashMap<>();
+        private MockScanResultProvider provider = new MockScanResultProvider(5, -145, -11);
+        private ScanState currentScanState = ScanState.NOT_SCANNING;
+
+        private Runnable resultsRunnable = new Runnable() {
+
+
+            @Override
+            public void run() {
+                for (BleScanCallbackWrapper wrapper : IBluetoothGatt.this.scanners.keySet()) {
+                    List<ScanResult> results = provider.getAllResults();
+                    for (ScanResult result : results) {
+                        wrapper.onScanResult(result);
+                    }
+                }
+            }
+        };
+
+        private Runnable intentDeliveryRunnable = new Runnable() {
+            @Override
+            public void run() {
+                for (BleScanCallbackWrapper wrapper : IBluetoothGatt.this.scanners.keySet()) {
+                    List<ScanResult> results = provider.getAllResults();
+                    for (ScanResult result : results) {
+                        wrapper.onScanResult(result);
+                    }
+                }
+            }
+        };
+
+        public void startScanForIntent(PendingIntent callbackIntent, ScanSettings settings, List<ScanFilter> filters, String packageName) {
+            singleThreadExecutor.schedule(resultsRunnable, TIME_BETWEEN_RESULTS, TimeUnit.MILLISECONDS);
+            if (settings.getScanMode() == ScanSettings.SCAN_MODE_LOW_LATENCY) {
+                currentScanState = ScanState.INTENT_SCANNING;
+            } else if (settings.getScanMode() == ScanSettings.SCAN_MODE_BALANCED) {
+                currentScanState = ScanState.INTENT_SCANNING;
+            } else if (settings.getScanMode() == ScanSettings.SCAN_MODE_LOW_POWER) {
+                currentScanState = ScanState.INTENT_SCANNING;
+            }
+        }
+
+        public void stopScanForIntent(PendingIntent callbackIntent, String packageName) {
+            /*
+            Set<Integer> keys = startedScanners.keySet();
+            for (Integer key : keys) {
+                if (key == scanId) {
+                    Timber.v("Cancelling scanner with id: %d", scanId);
+                    startedScanners.remove(scanId);
+                }
+            }
+            */
+        }
+
+        public void unregisterClient(int scannerId) {
+            Set<BleScanCallbackWrapper> keys = scanners.keySet();
+            for (BleScanCallbackWrapper key : keys) {
+                if (key.mScannerId == scannerId) {
+                    Timber.v("Cancelling scanner with id: %d", scannerId);
+                    scanners.remove(key);
+                }
+            }
+        }
+
+        public void startScan(int mScannerId, ScanSettings mSettings, List<ScanFilter> mFilters, List<List<ResultStorageDescriptor>> mResultStorages, String packageName) {
+            if (mSettings.getScanMode() == ScanSettings.SCAN_MODE_LOW_LATENCY) {
+                currentScanState = ScanState.LOW_LATENCY;
+            } else if (mSettings.getScanMode() == ScanSettings.SCAN_MODE_BALANCED) {
+                currentScanState = ScanState.BALANCED_LATENCY;
+            } else if (mSettings.getScanMode() == ScanSettings.SCAN_MODE_LOW_POWER) {
+                currentScanState = ScanState.HIGH_LATENCY;
+            }
+            Timber.v("Current scan state: %s", currentScanState);
+            SystemClock.sleep(TIME_BETWEEN_RESULTS);
+            resultsRunnable.run();
+        }
+
+        private enum ScanState {
+            NOT_SCANNING,
+            HIGH_LATENCY,
+            BALANCED_LATENCY,
+            LOW_LATENCY,
+            INTENT_SCANNING;
+        }
+
+        public void registerScanner(BleScanCallbackWrapper scanWrapper, WorkSource workSource) {
+            scanners.put(scanWrapper, workSource);
+            int i = 0;
+            for (BleScanCallbackWrapper wrapper : scanners.keySet()) {
+                if (wrapper.equals(scanWrapper)) {
+                    break;
+                }
+                i++;
+            }
+            scanWrapper.onScannerRegistered(0, i);
+        }
+
+        public void stopScan(int scanId) {
+            Set<Integer> keys = startedScanners.keySet();
+            for (Integer key : keys) {
+                if (key == scanId) {
+                    Timber.v("Cancelling scanner with id: %d", scanId);
+                    startedScanners.remove(scanId);
+                }
+            }
+        }
+
+        public void unregisterScanner(int scannerId) {
+            Set<BleScanCallbackWrapper> keys = scanners.keySet();
+            for (BleScanCallbackWrapper key : keys) {
+                if (key.mScannerId == scannerId) {
+                    Timber.v("Unregistering scanner with id: %d", scannerId);
+                    scanners.remove(scannerId);
+                }
+            }
+        }
+
+        public void flushPendingBatchResults(int scannerId) {
+            List<ScanResult> results = provider.getAllResults();
+            Set<BleScanCallbackWrapper> keys = scanners.keySet();
+            BleScanCallbackWrapper wrapper = null;
+            for (BleScanCallbackWrapper key : keys) {
+                if (key.mScannerId == scannerId) {
+                    wrapper = key;
+                    break;
+                }
+            }
+            if (wrapper != null) {
+                wrapper.onBatchScanResults(results);
+            }
+        }
+    }
+
+    /**
+     * Bluetooth GATT interface callbacks
+     */
+    private class BleScanCallbackWrapper {
+        private static final int REGISTRATION_CALLBACK_TIMEOUT_MILLIS = 2000;
+
+        private final ScanCallback mScanCallback;
+        private final List<ScanFilter> mFilters;
+        private final WorkSource mWorkSource;
+        private ScanSettings mSettings;
+        private IBluetoothGatt mBluetoothGatt;
+        private List<List<ResultStorageDescriptor>> mResultStorages;
+
+        // mLeHandle 0: not registered
+        // -2: registration failed because app is scanning to frequently
+        // -1: scan stopped or registration failed
+        // > 0: registered and scan started
+        private int mScannerId;
+
+        public BleScanCallbackWrapper(IBluetoothGatt bluetoothGatt,
+                                      List<ScanFilter> filters, ScanSettings settings,
+                                      WorkSource workSource, ScanCallback scanCallback,
+                                      List<List<ResultStorageDescriptor>> resultStorages) {
+            mBluetoothGatt = bluetoothGatt;
+            mFilters = filters;
+            mSettings = settings;
+            mWorkSource = workSource;
+            mScanCallback = scanCallback;
+            mScannerId = 0;
+            mResultStorages = resultStorages;
+        }
+
+        public void startRegistration() {
+            synchronized (this) {
+                // Scan stopped.
+                if (mScannerId == -1 || mScannerId == -2) return;
+                try {
+                    mBluetoothGatt.registerScanner(this, mWorkSource);
+                    wait(REGISTRATION_CALLBACK_TIMEOUT_MILLIS);
+                } catch (InterruptedException e) {
+                    Timber.tag(TAG).e(e, "application registration exception");
+                    postCallbackError(mScanCallback, ScanCallback.SCAN_FAILED_INTERNAL_ERROR);
+                }
+                if (mScannerId > 0) {
+                    mLeScanClients.put(mScanCallback, this);
+                } else {
+                    // Registration timed out or got exception, reset RscannerId to -1 so no
+                    // subsequent operations can proceed.
+                    if (mScannerId == 0) mScannerId = -1;
+
+                    // If scanning too frequently, don't report anything to the app.
+                    if (mScannerId == -2) return;
+
+                    postCallbackError(mScanCallback,
+                        ScanCallback.SCAN_FAILED_APPLICATION_REGISTRATION_FAILED);
+                }
+            }
+        }
+
+        public void stopLeScan() {
+            synchronized (this) {
+                if (mScannerId <= 0) {
+                    Log.e(TAG, "Error state, mLeHandle: " + mScannerId);
+                    return;
+                }
+                mBluetoothGatt.stopScan(mScannerId);
+                mBluetoothGatt.unregisterScanner(mScannerId);
+                mScannerId = -1;
+            }
+        }
+
+        void flushPendingBatchResults() {
+            synchronized (this) {
+                if (mScannerId <= 0) {
+                    Log.e(TAG, "Error state, mLeHandle: " + mScannerId);
+                    return;
+                }
+                mBluetoothGatt.flushPendingBatchResults(mScannerId);
+            }
+        }
+
+        /**
+         * Application interface registered - app is ready to go
+         */
+
+        public void onScannerRegistered(int status, int scannerId) {
+            Log.d(TAG, "onScannerRegistered() - status=" + status
+                + " scannerId=" + scannerId + " mScannerId=" + mScannerId);
+            synchronized (this) {
+                if (status == BluetoothGatt.GATT_SUCCESS) {
+                    if (mScannerId == -1) {
+                        // Registration succeeds after timeout, unregister client.
+                        mBluetoothGatt.unregisterClient(scannerId);
+                    } else {
+                        mScannerId = scannerId;
+                        mBluetoothGatt.startScan(mScannerId, mSettings, mFilters,
+                            mResultStorages,
+                            "com.fitbit.bluetooth.fbgatt");
+                    }
+                } else if (status == 0x06) {
+                    // applicaiton was scanning too frequently
+                    mScannerId = -2;
+                } else {
+                    // registration failed
+                    mScannerId = -1;
+                }
+                notifyAll();
+            }
+        }
+
+        /**
+         * Callback reporting an LE scan result.
+         */
+
+        public void onScanResult(final ScanResult scanResult) {
+            if (VDBG) Log.d(TAG, "onScanResult() - " + scanResult.toString());
+
+            // Check null in case the scan has been stopped
+            synchronized (this) {
+                if (mScannerId <= 0) return;
+            }
+            Handler handler = mHandler;
+            handler.post(new Runnable() {
+                @Override
+                public void run() {
+                    mScanCallback.onScanResult(ScanSettings.CALLBACK_TYPE_ALL_MATCHES, scanResult);
+                }
+            });
+        }
+
+
+        public void onBatchScanResults(final List<ScanResult> results) {
+            Handler handler = mHandler;
+            handler.post(new Runnable() {
+                @Override
+                public void run() {
+                    mScanCallback.onBatchScanResults(results);
+                }
+            });
+        }
+
+
+        public void onFoundOrLost(final boolean onFound, final ScanResult scanResult) {
+            if (VDBG) {
+                Log.d(TAG, "onFoundOrLost() - onFound = " + onFound + " " + scanResult.toString());
+            }
+
+            // Check null in case the scan has been stopped
+            synchronized (this) {
+                if (mScannerId <= 0) {
+                    return;
+                }
+            }
+            Handler handler = mHandler;
+            handler.post(new Runnable() {
+                @Override
+                public void run() {
+                    if (onFound) {
+                        mScanCallback.onScanResult(ScanSettings.CALLBACK_TYPE_FIRST_MATCH,
+                            scanResult);
+                    } else {
+                        mScanCallback.onScanResult(ScanSettings.CALLBACK_TYPE_MATCH_LOST,
+                            scanResult);
+                    }
+                }
+            });
+        }
+
+
+        public void onScanManagerErrorCallback(final int errorCode) {
+            if (VDBG) {
+                Log.d(TAG, "onScanManagerErrorCallback() - errorCode = " + errorCode);
+            }
+            synchronized (this) {
+                if (mScannerId <= 0) {
+                    return;
+                }
+            }
+            postCallbackError(mScanCallback, errorCode);
+        }
+    }
+
+    private int postCallbackErrorOrReturn(final ScanCallback callback, final int errorCode) {
+        if (callback == null) {
+            return errorCode;
+        } else {
+            postCallbackError(callback, errorCode);
+            return 0;
+        }
+    }
+
+    private void postCallbackError(final ScanCallback callback, final int errorCode) {
+        mHandler.post(new Runnable() {
+            @Override
+            public void run() {
+                callback.onScanFailed(errorCode);
+            }
+        });
+    }
+
+    private boolean isSettingsConfigAllowedForScan(ScanSettings settings) {
+
+        final int callbackType = settings.getCallbackType();
+        // Only support regular scan if no offloaded filter support.
+        if (callbackType == ScanSettings.CALLBACK_TYPE_ALL_MATCHES
+            && settings.getReportDelayMillis() == 0) {
+            return true;
+        }
+        return false;
+    }
+
+    private static final ScanFilter EMPTY = new ScanFilter.Builder().build();
+
+    private boolean isSettingsAndFilterComboAllowed(ScanSettings settings,
+                                                    List<ScanFilter> filterList) {
+        final int callbackType = settings.getCallbackType();
+        // If onlost/onfound is requested, a non-empty filter is expected
+        if ((callbackType & (ScanSettings.CALLBACK_TYPE_FIRST_MATCH
+            | ScanSettings.CALLBACK_TYPE_MATCH_LOST)) != 0) {
+            if (filterList == null) {
+                return false;
+            }
+            for (ScanFilter filter : filterList) {
+                if (filter.equals(EMPTY)) {
+                    return false;
+                }
+            }
+        }
+        return true;
+    }
+
+    private boolean isHardwareResourcesAvailableForScan(ScanSettings settings) {
+        Timber.v("Settings: %s", settings);
+        return true;
+    }
+}

--- a/src/test/java/com/fitbit/bluetooth/fbgatt/MockScanResultProvider.java
+++ b/src/test/java/com/fitbit/bluetooth/fbgatt/MockScanResultProvider.java
@@ -15,6 +15,7 @@ import android.bluetooth.le.ScanResult;
 import android.os.ParcelUuid;
 
 import org.junit.Assert;
+import org.mockito.Mockito;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -46,16 +47,16 @@ public class MockScanResultProvider {
         rnd.nextBytes(randomData);
         serviceDataMap.put(new ParcelUuid(UUID.fromString("adabfb00-6e7d-4601-bda2-bffaa68956ba")), randomData);
         for(int i=0; i < numberOfMockResults; i++) {
-            ScanResult result = mock(ScanResult.class);
-            BluetoothDevice device = mock(BluetoothDevice.class);
-            ScanRecord record = mock(ScanRecord.class);
-            when(device.getAddress()).thenReturn(randomMACAddress());
-            when(device.getName()).thenReturn("foobar-" + String.valueOf(i));
-            when(result.getDevice()).thenReturn(device);
-            when(result.getRssi()).thenReturn(-1 * (rnd.nextInt(Math.abs(minRssi) + 1 - Math.abs(maxRssi)) + Math.abs(maxRssi)));
+            ScanResult result = Mockito.mock(ScanResult.class);
+            BluetoothDevice device = Mockito.mock(BluetoothDevice.class);
+            ScanRecord record = Mockito.mock(ScanRecord.class);
+            Mockito.when(device.getAddress()).thenReturn(randomMACAddress());
+            Mockito.when(device.getName()).thenReturn("foobar-" + String.valueOf(i));
+            Mockito.when(result.getDevice()).thenReturn(device);
+            Mockito.when(result.getRssi()).thenReturn(-1 * (rnd.nextInt(Math.abs(minRssi) + 1 - Math.abs(maxRssi)) + Math.abs(maxRssi)));
             Assert.assertTrue("Rssi is less than zero", result.getRssi() < 0);
-            when(record.getDeviceName()).thenReturn("foobar-" + String.valueOf(i));
-            when(record.getServiceData()).thenReturn(serviceDataMap);
+            Mockito.when(record.getDeviceName()).thenReturn("foobar-" + String.valueOf(i));
+            Mockito.when(record.getServiceData()).thenReturn(serviceDataMap);
             scanResults.add(result);
         }
     }

--- a/src/test/java/com/fitbit/bluetooth/fbgatt/PeripheralScannerTest.java
+++ b/src/test/java/com/fitbit/bluetooth/fbgatt/PeripheralScannerTest.java
@@ -10,24 +10,35 @@ package com.fitbit.bluetooth.fbgatt;
 
 import android.bluetooth.le.ScanResult;
 import android.bluetooth.le.ScanSettings;
-import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
-import android.content.IntentFilter;
+import android.os.Handler;
 import android.os.Looper;
-import android.support.annotation.NonNull;
+import android.os.SystemClock;
+
+import junit.framework.TestCase;
 
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.mockito.stubbing.Answer;
 
 import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.fail;
+import androidx.annotation.NonNull;
+import timber.log.Timber;
+
+import static junit.framework.TestCase.assertTrue;
+import static org.junit.Assert.*;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -38,25 +49,59 @@ import static org.mockito.Mockito.when;
  */
 public class PeripheralScannerTest {
 
+    private static MockLollipopScanner mockScanner;
     Looper mockLooper;
-    public static Context mockContext;
+    public Context mockContext;
+    private FitbitGatt gatt;
+    private PeripheralScanner peripheralScanner;
+    private Handler mockHandler;
+    private ScheduledExecutorService singleThreadExecutor = Executors.newSingleThreadScheduledExecutor();
+    private Answer<Boolean> handlerPostAnswer = invocation -> {
+        Long delay = 0L;
+        if (invocation.getArguments().length > 1) {
+            delay = invocation.getArgument(1);
+        }
+        Runnable msg = invocation.getArgument(0);
+        if (msg != null) {
+            singleThreadExecutor.schedule(msg, delay, TimeUnit.MILLISECONDS);
+        }
+        return true;
+    };
 
     @BeforeClass
     public static void beforeClass(){
-        mockContext = mock(Context.class);
-        when(mockContext.getApplicationContext()).thenReturn(mockContext);
-        when(mockContext.registerReceiver(any(BroadcastReceiver.class), any(IntentFilter.class))).thenReturn(new Intent());
-
-        FitbitGatt.getInstance().start(mockContext);
-        if(FitbitGatt.getInstance().getPeripheralScanner() != null) {
-            FitbitGatt.getInstance().getPeripheralScanner().setMockMode(true);
-        }
+        mockScanner = MockLollipopScanner.BluetoothAdapter.getBluetoothLeScanner();
     }
 
     @Before
     public void before(){
-        mockLooper = mock(Looper.class);
+        MockLollipopScanner.BluetoothAdapter.turnBluetoothOn();
+        Looper mockMainThreadLooper = mock(Looper.class);
+        Thread mockMainThread = mock(Thread.class);
+        when(mockMainThread.getName()).thenReturn("Irvin's mock thread");
+        when(mockMainThreadLooper.getThread()).thenReturn(mockMainThread);
+        mockContext = mock(Context.class);
+        when(mockContext.getApplicationContext()).thenReturn(mockContext);
+        when(mockContext.registerReceiver(any(), any())).thenReturn(new Intent("some custom action"));
+        when(mockContext.getMainLooper()).thenReturn(mockMainThreadLooper);
+        mockHandler = mock(Handler.class);
+        doAnswer(handlerPostAnswer).when(mockHandler).post(any(Runnable.class));
+        doAnswer(handlerPostAnswer).when(mockHandler).postDelayed(any(Runnable.class), anyLong());
+        when(mockHandler.getLooper()).thenReturn(mockMainThreadLooper);
+        gatt = FitbitGatt.getInstance();
+        gatt.start(mockContext);
+        gatt.setScannerMockMode(true);
         FitbitGatt.getInstance().clearConnectionsMap();
+        if(gatt.getPeripheralScanner() == null) {
+            fail();
+            return;
+        }
+        peripheralScanner = gatt.getPeripheralScanner();
+        peripheralScanner.setHandler(mockHandler);
+        peripheralScanner.injectMockScanner(mockScanner);
+        peripheralScanner.cancelPeriodicalScan(mockContext);
+        peripheralScanner.cancelHighPriorityScan(mockContext);
+        peripheralScanner.cancelPendingIntentBasedBackgroundScan();
     }
 
     @After
@@ -64,422 +109,144 @@ public class PeripheralScannerTest {
 
     @Test
     public void testRssiFilteredScanNoResults() {
-        if(FitbitGatt.getInstance().getPeripheralScanner() == null) {
-            fail();
-        }
-        assertFalse(FitbitGatt.getInstance().getPeripheralScanner().isScanning());
+        assertFalse(peripheralScanner.isScanning());
         MockScanResultProvider provider = new MockScanResultProvider(10, -167, -40);
-        FitbitGatt.getInstance().getPeripheralScanner().addRssiFilter(-10);
+        peripheralScanner.addRssiFilter(-10);
         List<ScanResult> results = provider.getAllResults();
-        FitbitGatt.getInstance().getPeripheralScanner().populateMockScanResultBatchValues(results);
-        Assert.assertEquals(0, FitbitGatt.getInstance().getNewlyScannedDevicesOnly().size());
+        peripheralScanner.populateMockScanResultBatchValues(results);
+        Assert.assertEquals(0, gatt.getNewlyScannedDevicesOnly().size());
     }
 
     @Test
     public void testRssiFilteredScanResults() {
-        if(FitbitGatt.getInstance().getPeripheralScanner() == null) {
-            fail();
-        }
-        assertFalse(FitbitGatt.getInstance().getPeripheralScanner().isScanning());
+        assertFalse(peripheralScanner.isScanning());
         MockScanResultProvider provider = new MockScanResultProvider(10, -60, -40);
-        FitbitGatt.getInstance().getPeripheralScanner().addRssiFilter(-60);
+        peripheralScanner.addRssiFilter(-60);
         List<ScanResult> results = provider.getAllResults();
-        FitbitGatt.FitbitGattCallback cb = new FitbitGatt.FitbitGattCallback() {
+        NoOpGattCallback cb = new NoOpGattCallback() {
 
             @Override
             public void onBluetoothPeripheralDiscovered(@NonNull GattConnection connection) {
                 Assert.assertTrue("RSSI must be above -60", connection.getDevice().getRssi() > -60);
-            }
-
-            @Override
-            public void onBluetoothPeripheralDisconnected(@NonNull GattConnection connection) {
-
-            }
-
-            @Override
-            public void onFitbitGattReady() {
-
-            }
-
-            @Override
-            public void onScanStarted() {
-
-            }
-
-            @Override
-            public void onScanStopped() {
-
-            }
-
-            @Override
-            public void onPendingIntentScanStopped() {
-
-            }
-
-            @Override
-            public void onPendingIntentScanStarted() {
-
-            }
-
-            @Override
-            public void onBluetoothOff() {
-
-            }
-
-            @Override
-            public void onBluetoothOn() {
-
-            }
-
-            @Override
-            public void onBluetoothTurningOn() {
-
-            }
-
-            @Override
-            public void onBluetoothTurningOff() {
-
+                gatt.unregisterGattEventListener(this);
             }
         };
-        FitbitGatt.getInstance().registerGattEventListener(cb);
-        FitbitGatt.getInstance().getPeripheralScanner().populateMockScanResultBatchValues(results);
+        gatt.registerGattEventListener(cb);
+        gatt.getPeripheralScanner().populateMockScanResultBatchValues(results);
     }
 
     @Test
     public void testConnectionAlreadyInMapDisconnectedScanResult() {
         MockScanResultProvider provider = new MockScanResultProvider(10, -167, -40);
-        if(FitbitGatt.getInstance().getPeripheralScanner() == null) {
-            fail();
-        }
-        FitbitGatt.getInstance().getPeripheralScanner().addRssiFilter(-10);
+        peripheralScanner.addRssiFilter(-10);
         ScanResult result = provider.getAllResults().get(0);
         FitbitBluetoothDevice device = new FitbitBluetoothDevice(result.getDevice());
         GattConnection conn = new GattConnection(device, mockLooper);
         conn.setMockMode(true);
         conn.setState(GattState.DISCONNECTED);
-        FitbitGatt.getInstance().getConnectionMap().put(device, conn);
-        FitbitGatt.FitbitGattCallback cb = new FitbitGatt.FitbitGattCallback() {
+        gatt.getConnectionMap().put(device, conn);
+        NoOpGattCallback cb = new NoOpGattCallback() {
 
             @Override
             public void onBluetoothPeripheralDiscovered(@NonNull GattConnection connection) {
                 Assert.assertEquals(conn, connection);
+                gatt.unregisterGattEventListener(this);
             }
 
-            @Override
-            public void onBluetoothPeripheralDisconnected(@NonNull GattConnection connection) {
-
-            }
-
-            @Override
-            public void onFitbitGattReady() {
-
-            }
-
-            @Override
-            public void onScanStarted() {
-
-            }
-
-            @Override
-            public void onScanStopped() {
-
-            }
-
-            @Override
-            public void onPendingIntentScanStopped() {
-
-            }
-
-            @Override
-            public void onPendingIntentScanStarted() {
-
-            }
-
-            @Override
-            public void onBluetoothOff() {
-
-            }
-
-            @Override
-            public void onBluetoothOn() {
-
-            }
-
-            @Override
-            public void onBluetoothTurningOn() {
-
-            }
-
-            @Override
-            public void onBluetoothTurningOff() {
-
-            }
         };
-        FitbitGatt.getInstance().registerGattEventListener(cb);
-        FitbitGatt.getInstance().getPeripheralScanner().populateMockScanResultIndividualValue(ScanSettings.CALLBACK_TYPE_FIRST_MATCH, result);
+        gatt.registerGattEventListener(cb);
+        peripheralScanner.populateMockScanResultIndividualValue(ScanSettings.CALLBACK_TYPE_FIRST_MATCH, result);
     }
 
     @Test
     public void testConnectionAlreadyInMapScannedPropertiesChangedRssi() {
         MockScanResultProvider provider = new MockScanResultProvider(10, -167, -40);
-        if(FitbitGatt.getInstance().getPeripheralScanner() == null) {
-            fail();
-        }
-        FitbitGatt.getInstance().getPeripheralScanner().addRssiFilter(-10);
+        peripheralScanner.addRssiFilter(-10);
         ScanResult result = provider.getAllResults().get(0);
         FitbitBluetoothDevice device = new FitbitBluetoothDevice(result.getDevice());
         device.setScanRecord(result.getScanRecord());
         GattConnection conn = new GattConnection(device, mockLooper);
         conn.setMockMode(true);
         conn.setState(GattState.DISCONNECTED);
-        FitbitGatt.getInstance().getConnectionMap().put(device, conn);
+        gatt.getConnectionMap().put(device, conn);
         FitbitBluetoothDevice.DevicePropertiesChangedCallback propChanged = device1 -> Assert.assertEquals(1, device1.getRssi());
         device.addDevicePropertiesChangedListener(propChanged);
         device.setRssi(1);
         device.removeDevicePropertiesChangedListener(propChanged);
-        FitbitGatt.FitbitGattCallback cb = new FitbitGatt.FitbitGattCallback() {
+        NoOpGattCallback cb = new NoOpGattCallback() {
 
             @Override
             public void onBluetoothPeripheralDiscovered(@NonNull GattConnection connection) {
                 Assert.assertEquals(conn, connection);
+                gatt.unregisterGattEventListener(this);
             }
 
-            @Override
-            public void onBluetoothPeripheralDisconnected(@NonNull GattConnection connection) {
-
-            }
-
-            @Override
-            public void onFitbitGattReady() {
-
-            }
-
-            @Override
-            public void onScanStarted() {
-
-            }
-
-            @Override
-            public void onScanStopped() {
-
-            }
-
-            @Override
-            public void onPendingIntentScanStopped() {
-
-            }
-
-            @Override
-            public void onPendingIntentScanStarted() {
-
-            }
-
-            @Override
-            public void onBluetoothOff() {
-
-            }
-
-            @Override
-            public void onBluetoothOn() {
-
-            }
-
-            @Override
-            public void onBluetoothTurningOn() {
-
-            }
-
-            @Override
-            public void onBluetoothTurningOff() {
-
-            }
         };
-        FitbitGatt.getInstance().registerGattEventListener(cb);
-        FitbitGatt.getInstance().addScannedDevice(device);
+        gatt.registerGattEventListener(cb);
+        gatt.addScannedDevice(device);
     }
 
     @Test
     public void testConnectionAlreadyInMapScannedPropertiesChangedName() {
         MockScanResultProvider provider = new MockScanResultProvider(10, -167, -40);
-        if(FitbitGatt.getInstance().getPeripheralScanner() == null) {
-            fail();
-        }
-        FitbitGatt.getInstance().getPeripheralScanner().addRssiFilter(-10);
+        peripheralScanner.addRssiFilter(-10);
         ScanResult result = provider.getAllResults().get(0);
         FitbitBluetoothDevice device = new FitbitBluetoothDevice(result.getDevice());
         device.setScanRecord(result.getScanRecord());
         GattConnection conn = new GattConnection(device, mockLooper);
         conn.setMockMode(true);
         conn.setState(GattState.DISCONNECTED);
-        FitbitGatt.getInstance().getConnectionMap().put(device, conn);
+        gatt.getConnectionMap().put(device, conn);
         FitbitBluetoothDevice.DevicePropertiesChangedCallback propChanged = device1 -> Assert.assertEquals("Yogurt", device1.getName());
         device.addDevicePropertiesChangedListener(propChanged);
         device.setName("Yogurt");
         device.removeDevicePropertiesChangedListener(propChanged);
-        FitbitGatt.FitbitGattCallback cb = new FitbitGatt.FitbitGattCallback() {
+        NoOpGattCallback cb = new NoOpGattCallback() {
 
             @Override
             public void onBluetoothPeripheralDiscovered(@NonNull GattConnection connection) {
                 Assert.assertEquals(conn, connection);
+                gatt.unregisterGattEventListener(this);
             }
 
-            @Override
-            public void onBluetoothPeripheralDisconnected(@NonNull GattConnection connection) {
-
-            }
-
-            @Override
-            public void onFitbitGattReady() {
-
-            }
-
-            @Override
-            public void onScanStarted() {
-
-            }
-
-            @Override
-            public void onScanStopped() {
-
-            }
-
-            @Override
-            public void onPendingIntentScanStopped() {
-
-            }
-
-            @Override
-            public void onPendingIntentScanStarted() {
-
-            }
-
-            @Override
-            public void onBluetoothOff() {
-
-            }
-
-            @Override
-            public void onBluetoothOn() {
-
-            }
-
-            @Override
-            public void onBluetoothTurningOn() {
-
-            }
-
-            @Override
-            public void onBluetoothTurningOff() {
-
-            }
         };
-        FitbitGatt.getInstance().registerGattEventListener(cb);
-        FitbitGatt.getInstance().addScannedDevice(device);
+        gatt.registerGattEventListener(cb);
+        gatt.addScannedDevice(device);
     }
 
     @Test
     public void testConnectionAlreadyInMapScannedPropertiesChangedScanRecord() {
         MockScanResultProvider provider = new MockScanResultProvider(10, -167, -40);
-        if(FitbitGatt.getInstance().getPeripheralScanner() == null) {
-            fail();
-        }
-        FitbitGatt.getInstance().getPeripheralScanner().addRssiFilter(-10);
+        peripheralScanner.addRssiFilter(-10);
         ScanResult result = provider.getAllResults().get(0);
         FitbitBluetoothDevice device = new FitbitBluetoothDevice(result.getDevice());
         device.setScanRecord(result.getScanRecord());
         GattConnection conn = new GattConnection(device, mockLooper);
         conn.setMockMode(true);
         conn.setState(GattState.DISCONNECTED);
-        FitbitGatt.getInstance().getConnectionMap().put(device, conn);
+        gatt.getConnectionMap().put(device, conn);
         FitbitBluetoothDevice.DevicePropertiesChangedCallback propChanged = device1 -> Assert.assertNull(device1.getScanRecord());
         device.addDevicePropertiesChangedListener(propChanged);
         device.setScanRecord(null);
         device.removeDevicePropertiesChangedListener(propChanged);
-        FitbitGatt.FitbitGattCallback cb = new FitbitGatt.FitbitGattCallback() {
+        NoOpGattCallback cb = new NoOpGattCallback() {
 
             @Override
             public void onBluetoothPeripheralDiscovered(@NonNull GattConnection connection) {
                 Assert.assertEquals(conn, connection);
+                gatt.unregisterGattEventListener(this);
             }
 
-            @Override
-            public void onBluetoothPeripheralDisconnected(@NonNull GattConnection connection) {
-
-            }
-
-            @Override
-            public void onFitbitGattReady() {
-
-            }
-
-            @Override
-            public void onScanStarted() {
-
-            }
-
-            @Override
-            public void onScanStopped() {
-
-            }
-
-            @Override
-            public void onPendingIntentScanStopped() {
-
-            }
-
-            @Override
-            public void onPendingIntentScanStarted() {
-
-            }
-
-            @Override
-            public void onBluetoothOff() {
-
-            }
-
-            @Override
-            public void onBluetoothOn() {
-
-            }
-
-            @Override
-            public void onBluetoothTurningOn() {
-
-            }
-
-            @Override
-            public void onBluetoothTurningOff() {
-
-            }
         };
-        FitbitGatt.getInstance().registerGattEventListener(cb);
-        FitbitGatt.getInstance().addScannedDevice(device);
+        gatt.registerGattEventListener(cb);
+        gatt.addScannedDevice(device);
     }
 
     @Test
     public void testStopHighPriorityScanCallbackWorks(){
         final boolean[] startHP = {false};
-        FitbitGatt.FitbitGattCallback cb = new FitbitGatt.FitbitGattCallback() {
+        NoOpGattCallback cb = new NoOpGattCallback() {
 
-            @Override
-            public void onBluetoothPeripheralDiscovered(@NonNull GattConnection connection) {
-
-            }
-
-            @Override
-            public void onBluetoothPeripheralDisconnected(@NonNull GattConnection connection) {
-
-            }
-
-            @Override
-            public void onFitbitGattReady() {
-
-            }
-
-            @Override
-            public void onScanStarted() {
-
-            }
 
             @Override
             public void onScanStopped() {
@@ -495,45 +262,161 @@ public class PeripheralScannerTest {
                 }
             }
 
-            @Override
-            public void onPendingIntentScanStopped() {
+        };
+        gatt.registerGattEventListener(cb);
+        peripheralScanner.addRssiFilter(-10);
+        peripheralScanner.startPeriodicScan(mockContext);
+        peripheralScanner.startHighPriorityScan(mockContext);
+        peripheralScanner.cancelHighPriorityScan(mockContext);
+        gatt.unregisterGattEventListener(cb);
+    }
 
+    @Test
+    public void testPeripheralScannerStartLowLatencyScanTimeoutPeriodicShouldNotBeRunning() {
+        CountDownLatch cdl = new CountDownLatch(2);
+        // we want to do this so that we don't end up with a super long wait
+        peripheralScanner.setInstrumentationTestMode(true);
+        peripheralScanner.addRssiFilter(-10);
+        final boolean[] didStart = new boolean[] { false };
+        NoOpGattCallback cb = new NoOpGattCallback() {
+            @Override
+            public void onScanStarted() {
+                didStart[0] = true;
+                cdl.countDown();
             }
 
             @Override
-            public void onPendingIntentScanStarted() {
-
-            }
-
-            @Override
-            public void onBluetoothOff() {
-
-            }
-
-            @Override
-            public void onBluetoothOn() {
-
-            }
-
-            @Override
-            public void onBluetoothTurningOn() {
-
-            }
-
-            @Override
-            public void onBluetoothTurningOff() {
-
+            public void onScanStopped(){
+                if(didStart[0]) {
+                    mockHandler.postDelayed(() -> {
+                        assertFalse(peripheralScanner.isPeriodicalScanEnabled());
+                        cdl.countDown();
+                    }, 500);
+                }
             }
         };
-        FitbitGatt.getInstance().registerGattEventListener(cb);
-        if(FitbitGatt.getInstance().getPeripheralScanner() == null) {
-            fail();
-            return;
+        gatt.registerGattEventListener(cb);
+        boolean didHighPriorityScanStart = peripheralScanner.startHighPriorityScan(mockContext);
+        if(!didHighPriorityScanStart) {
+            fail("Couldn't start high priority scan");
         }
-        FitbitGatt.getInstance().getPeripheralScanner().addRssiFilter(-10);
-        FitbitGatt.getInstance().getPeripheralScanner().startPeriodicScan(mockContext);
-        FitbitGatt.getInstance().getPeripheralScanner().startHighPriorityScan(mockContext);
-        FitbitGatt.getInstance().getPeripheralScanner().cancelHighPriorityScan(mockContext);
-        FitbitGatt.getInstance().unregisterGattEventListener(cb);
+        try {
+            boolean result = cdl.await(5, TimeUnit.SECONDS);
+            if(!result) {
+                TestCase.fail("Test Timeout");
+            }
+        } catch (InterruptedException e) {
+            Timber.e(e, "Failed test");
+            fail();
+        } finally {
+            gatt.unregisterGattEventListener(cb);
+            peripheralScanner.setInstrumentationTestMode(false);
+        }
+    }
+
+    @Test
+    public void testPeripheralScannerStartHighAndLowLatencyScanTimeoutPeriodicShouldBeRunning() {
+        CountDownLatch cdl = new CountDownLatch(2);
+        // we want to do this so that we don't end up with a super long wait
+        peripheralScanner.setInstrumentationTestMode(true);
+        peripheralScanner.addRssiFilter(-10);
+        final boolean[] didStart = new boolean[] { false };
+        NoOpGattCallback cb = new NoOpGattCallback() {
+            @Override
+            public void onScanStarted() {
+                if(peripheralScanner.isPeriodicalScanEnabled()) {
+                    didStart[0] = true;
+                    cdl.countDown();
+                } else {
+                    fail("Start shouldn't be called until periodical scan is enabled");
+                }
+            }
+
+            @Override
+            public void onScanStopped(){
+                if(didStart[0]) {
+                    cdl.countDown();
+                    assertTrue(peripheralScanner.isPeriodicalScanEnabled());
+                }
+            }
+        };
+        gatt.registerGattEventListener(cb);
+        boolean started = peripheralScanner.startPeriodicScan(mockContext);
+        if(!started) {
+            fail("The periodical scan never started");
+        }
+        started = peripheralScanner.startHighPriorityScan(mockContext);
+        if(!started) {
+            fail("The high priority scan never started");
+        }
+        try {
+            boolean result = cdl.await(5, TimeUnit.SECONDS);
+            if(!result) {
+                TestCase.fail("Test Timeout");
+            }
+        } catch (InterruptedException e) {
+            fail("Failed test, interrupted exception");
+        } finally {
+            gatt.unregisterGattEventListener(cb);
+            peripheralScanner.setInstrumentationTestMode(false);
+        }
+    }
+
+    public static class NoOpGattCallback implements FitbitGatt.FitbitGattCallback {
+
+        @Override
+        public void onBluetoothPeripheralDiscovered(GattConnection connection) {
+
+        }
+
+        @Override
+        public void onBluetoothPeripheralDisconnected(GattConnection connection) {
+
+        }
+
+        @Override
+        public void onFitbitGattReady() {
+
+        }
+
+        @Override
+        public void onScanStarted() {
+
+        }
+
+        @Override
+        public void onScanStopped() {
+
+        }
+
+        @Override
+        public void onPendingIntentScanStopped() {
+
+        }
+
+        @Override
+        public void onPendingIntentScanStarted() {
+
+        }
+
+        @Override
+        public void onBluetoothOff() {
+
+        }
+
+        @Override
+        public void onBluetoothOn() {
+
+        }
+
+        @Override
+        public void onBluetoothTurningOn() {
+
+        }
+
+        @Override
+        public void onBluetoothTurningOff() {
+
+        }
     }
 }

--- a/src/test/java/com/fitbit/bluetooth/fbgatt/tools/GattPluginTests.java
+++ b/src/test/java/com/fitbit/bluetooth/fbgatt/tools/GattPluginTests.java
@@ -6,7 +6,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-package com.fitbit.tools;
+package com.fitbit.bluetooth.fbgatt.tools;
 
 import android.bluetooth.BluetoothGattCharacteristic;
 import android.bluetooth.BluetoothGattDescriptor;


### PR DESCRIPTION
## Fixes Complexity of scanning

### description
Will make it easier for a developer who intends to try to connect to a peripheral defined by a scan filter then remain connected anytime the device is within range.

### changes
- Adding an easier scanner to use
- Adding a stubbed scanner behind an interface for testing
- Improving the test coverage around the scanning
- Fixing a flaky test

### how tested
Tested via internal tools by me, all unit and instrumented tests run and passing
