### PR TITLE
Fixes#[Internal Ticket] - Crash with more than 1000 receivers

### DIFF
--- a/src/androidTest/java/com/fitbit/bluetooth/fbgatt/FitbitGattTest.java
+++ b/src/androidTest/java/com/fitbit/bluetooth/fbgatt/FitbitGattTest.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2019 Fitbit, Inc. All rights reserved.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+package com.fitbit.bluetooth.fbgatt;
+
+import android.content.Context;
+import android.support.test.InstrumentationRegistry;
+import android.support.test.runner.AndroidJUnit4;
+
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+import timber.log.Timber;
+
+import static org.junit.Assert.*;
+
+/**
+ * Primarily to test start idempotency, then because anyone can use the broadcast receiver, and it
+ * might be started by the system as it could be added to the manifest ( is probably added to
+ * the manifest ) and start() will try to manually register, it could register twice, for that
+ * reason we'll ensure that we unregister first, then register it programmatically if desired.
+ *
+ * Created by iowens on 8/14/19.
+ */
+
+@RunWith(AndroidJUnit4.class)
+public class FitbitGattTest {
+    static Context context;
+
+    @BeforeClass
+    public static void beforeClass() {
+        context = InstrumentationRegistry.getContext();
+    }
+
+    @Test
+    public void testStartMultipleRegistrations(){
+        ArrayList<Runnable> runnables = new ArrayList<>();
+        for(int i=0; i < 1001; i++) {
+            final int internalCount = i;
+            runnables.add(() -> {
+                Timber.i("Calling start #%d...", internalCount);
+                FitbitGatt.getInstance().start(context);
+            });
+        }
+        try {
+            assertConcurrent("Testing start", runnables, 30);
+            assertEquals("No matter how many times we call register it should be 1", 1, LowEnergyAclListener.timesRegistered.get());
+        } catch (InterruptedException e) {
+            fail("Test was interrupted");
+        }
+    }
+
+    @Test
+    public void testBroadcastReceiverAlone(){
+        FitbitGatt.getInstance().start(context);
+        LowEnergyAclListener listener = FitbitGatt.getInstance().aclListener;
+        ArrayList<Runnable> runnables = new ArrayList<>();
+        for(int i=0; i < 1001; i++) {
+            final int internalCount = i;
+            runnables.add(() -> {
+                Timber.i("Calling start #%d...", internalCount);
+                listener.register(context);
+            });
+        }
+        try {
+            assertConcurrent("Testing start", runnables, 30);
+            assertEquals("No matter how many times we call register it should be 1", 1, LowEnergyAclListener.timesRegistered.get());
+        } catch (InterruptedException e) {
+            fail("Test was interrupted");
+        }
+    }
+
+    private static void assertConcurrent(final String message, final List<? extends Runnable> runnables, final int maxTimeoutSeconds) throws InterruptedException {
+        final int numThreads = runnables.size();
+        final List<Throwable> exceptions = Collections.synchronizedList(new ArrayList<>());
+        final ExecutorService threadPool = Executors.newFixedThreadPool(numThreads);
+        try {
+            final CountDownLatch allExecutorThreadsReady = new CountDownLatch(numThreads);
+            final CountDownLatch afterInitBlocker = new CountDownLatch(1);
+            final CountDownLatch allDone = new CountDownLatch(numThreads);
+            for (final Runnable submittedTestRunnable : runnables) {
+                threadPool.submit(() -> {
+                    allExecutorThreadsReady.countDown();
+                    try {
+                        afterInitBlocker.await();
+                        submittedTestRunnable.run();
+                    } catch (final Throwable e) {
+                        exceptions.add(e);
+                    } finally {
+                        allDone.countDown();
+                    }
+                });
+            }
+            // wait until all threads are ready
+            assertTrue("Timeout initializing threads! Perform long lasting initializations before passing runnables to assertConcurrent", allExecutorThreadsReady.await(runnables.size() * 10, TimeUnit.MILLISECONDS));
+            // start all test runners
+            afterInitBlocker.countDown();
+            assertTrue(message +" timeout! More than" + maxTimeoutSeconds + "seconds", allDone.await(maxTimeoutSeconds, TimeUnit.SECONDS));
+        } finally {
+            threadPool.shutdownNow();
+        }
+        assertTrue(message + "failed with exception(s)" + exceptions, exceptions.isEmpty());
+    }
+}

--- a/src/main/java/com/fitbit/bluetooth/fbgatt/GattServerCallback.java
+++ b/src/main/java/com/fitbit/bluetooth/fbgatt/GattServerCallback.java
@@ -20,6 +20,8 @@ import android.os.Build;
 import android.os.Handler;
 import android.os.HandlerThread;
 import android.os.Looper;
+
+import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.VisibleForTesting;
 
@@ -44,7 +46,7 @@ import timber.log.Timber;
 
 class GattServerCallback extends BluetoothGattServerCallback {
 
-    private final Handler handler;
+    private final @NonNull Handler handler;
 
     private final List<GattServerListener> listeners;
     private GattUtils gattUtils = new GattUtils();
@@ -91,6 +93,10 @@ class GattServerCallback extends BluetoothGattServerCallback {
 
     private String getDeviceMacFromDevice(BluetoothDevice device) {
         return gattUtils.safeGetBtDeviceName(device);
+    }
+
+    @NonNull Handler getServerCallbackHandler(){
+        return this.handler;
     }
 
     @Override

--- a/src/main/java/com/fitbit/bluetooth/fbgatt/tools/GattPlugin.java
+++ b/src/main/java/com/fitbit/bluetooth/fbgatt/tools/GattPlugin.java
@@ -143,8 +143,7 @@ public class GattPlugin implements DumperPlugin, FitbitGatt.FitbitGattCallback, 
     private static final String GATT_CLIENT_CHANGED_MTU = "gatt_client_changed_mtu";
     private DumperContext dumperContext;
 
-    enum GattCommand {
-
+    public enum GattCommand {
         HELP("help", "h", "Description: Will print this help"),
         ADD_LOCAL_GATT_SERVER_SERVICE("add-local-gatt-server-service", "algss", "<uuid>\n\nDescription: Will add a local gatt server service to the mobile device"),
         ADD_LOCAL_GATT_SERVER_CHARACTERISTIC("add-local-gatt-server-characteristic", "algsc",

--- a/src/test/java/com/fitbit/bluetooth/fbgatt/PeripheralScannerTest.java
+++ b/src/test/java/com/fitbit/bluetooth/fbgatt/PeripheralScannerTest.java
@@ -301,7 +301,7 @@ public class PeripheralScannerTest {
             fail("Couldn't start high priority scan");
         }
         try {
-            boolean result = cdl.await(5, TimeUnit.SECONDS);
+            boolean result = cdl.await(8, TimeUnit.SECONDS);
             if(!result) {
                 TestCase.fail("Test Timeout");
             }
@@ -350,7 +350,7 @@ public class PeripheralScannerTest {
             fail("The high priority scan never started");
         }
         try {
-            boolean result = cdl.await(5, TimeUnit.SECONDS);
+            boolean result = cdl.await(8, TimeUnit.SECONDS);
             if(!result) {
                 TestCase.fail("Test Timeout");
             }


### PR DESCRIPTION
Fixes # [internal ticket]

### description
If a developer registered the receiver programmatically and in the
manifest this could lead to a crash on some phones where the intent
based scan seems to return results on different threads leading
to a start race that got through the atomic boolean get.

Interesting side-note, on the Pixel and well behaved phones
too many registrations of the same instance does not result
in a crash, only a log statement indicating that this instance
is already registered, however on some poorly behaved phones like
the Samsung A8 this results in a crash, this may be fixed in later
Android versions but at least some versions crash.

This should not have been possible as the only place that this could have happened
was from a broadcast receiver which should only be executing on the main thread
preventing concurrent access, so synchronized ought not to have been necessary...
that we saw this in the wild indicates that this may not always be the case with the intent based scan.

### changes
- Added tests for this behavior, guard logging so that a dev knows that
this is going on
- made sure that this receiver could only be registered once.

### how tested
Tested in gucci gatt manually on a Pixel 3 XL, and A8 as well as automated
testing
