### PR TITLE
Handles CME crash in Android stack and adding tests

### DIFF
--- a/src/main/java/com/fitbit/bluetooth/fbgatt/GattClientCallback.java
+++ b/src/main/java/com/fitbit/bluetooth/fbgatt/GattClientCallback.java
@@ -12,6 +12,7 @@ import android.bluetooth.BluetoothGatt;
 import android.bluetooth.BluetoothGattCallback;
 import android.bluetooth.BluetoothGattCharacteristic;
 import android.bluetooth.BluetoothGattDescriptor;
+import android.bluetooth.BluetoothGattService;
 import android.bluetooth.BluetoothProfile;
 import android.content.Context;
 import android.os.Build;
@@ -291,6 +292,7 @@ public class GattClientCallback extends BluetoothGattCallback {
         }
         GattConnection conn = FitbitGatt.getInstance().getConnection(gatt.getDevice());
         if(conn != null) {
+            List<BluetoothGattService> discoveredServices = gatt.getServices();
             // since this is one of the events that could happen asynchronously, we will
             // need to iterate through our connection listeners
             handler.post(() -> {
@@ -304,7 +306,7 @@ public class GattClientCallback extends BluetoothGattCallback {
                     }
                     asyncConnListener.onServicesDiscovered(builder
                         .transactionName(GattClientDiscoverServicesTransaction.NAME)
-                        .serverServices(gatt.getServices())
+                        .serverServices(discoveredServices)
                         .gattState(conn.getGattState())
                         .responseStatus(GattDisconnectReason.getReasonForCode(status).ordinal()).build(), conn);
                 }

--- a/src/main/java/com/fitbit/bluetooth/fbgatt/PeripheralScanner.java
+++ b/src/main/java/com/fitbit/bluetooth/fbgatt/PeripheralScanner.java
@@ -61,7 +61,8 @@ class PeripheralScanner {
     private static final int DEFAULT_SCAN_BACKOFF_MULTIPLIER = 1;
 
     Handler mHandler;
-    private final Runnable scanTimeoutRunnable = new ScanTimeoutRunnable();
+    @VisibleForTesting
+    final Runnable scanTimeoutRunnable = new ScanTimeoutRunnable();
     private final Runnable periodicRunnable = new PeriodicScanRunnable();
     private ScannerInterface scanner;
     private int scanMode = ScanSettings.SCAN_MODE_LOW_POWER;


### PR DESCRIPTION
Fixes # Handles CME crash in Android stack

### description
It turns out that if a gatt.getServices() is called from a different thread than the one on which the
gatt instance was returned, such as a handler from a binder, there can be a CME as the current core BluetoothGatt implementation in Android does not use an iterator and remove from the copy.

This may also occur if discovery is happening while the gatt services on the remote peripheral are changing.  Thanks to ilepadatescu@fitbit.com for making the change ... note, this is a speculative fix, in practice it has mitigated the crash, but it may not have entirely eliminated it

### changes
- Fixed flaky tests ( iowens@fitbit.com )
- Ensured getServices only happens on the provided binder thread in the callback (ilepadatescu@fitbit.com)

### how tested
Evaluated in prod using firebase to verify fewer crashes, and on Pixel 3 XL
