### PR TITLE
Fixing crash with NPE in add while clear on aggressive BT toggling

### DIFF
--- a/src/androidTest/java/com/fitbit/bluetooth/fbgatt/GattServerTests.java
+++ b/src/androidTest/java/com/fitbit/bluetooth/fbgatt/GattServerTests.java
@@ -26,6 +26,8 @@ import androidx.annotation.NonNull;
 import android.support.test.InstrumentationRegistry;
 import android.support.test.runner.AndroidJUnit4;
 
+import org.junit.After;
+import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -40,6 +42,7 @@ import java.util.concurrent.TimeUnit;
 import timber.log.Timber;
 
 import static junit.framework.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 @RunWith(AndroidJUnit4.class)
 public class GattServerTests {
@@ -86,6 +89,11 @@ public class GattServerTests {
         dncs.addCharacteristic(flsChar);
     }
 
+    @AfterClass
+    public static void afterClass(){
+        gatt.getServer().getServer().clearServices();
+    }
+
     @Test
     public void initWithServices() throws InterruptedException {
         ArrayList<BluetoothGattService> services = new ArrayList<>();
@@ -109,6 +117,9 @@ public class GattServerTests {
             public void onFitbitGattReady() {
                 Timber.v("all services up");
                 Assert.assertTrue(FitbitGatt.getInstance().isStarted());
+                assertNotNull(gatt.getServer().getServer().getService(main.getUuid()));
+                assertNotNull(gatt.getServer().getServer().getService(liveData.getUuid()));
+                assertNotNull(gatt.getServer().getServer().getService(dncs.getUuid()));
                 gatt.getServer().setState(GattState.IDLE);
                 cdl.countDown();
             }

--- a/src/main/java/com/fitbit/bluetooth/fbgatt/CompositeServerTransaction.java
+++ b/src/main/java/com/fitbit/bluetooth/fbgatt/CompositeServerTransaction.java
@@ -28,15 +28,15 @@ import timber.log.Timber;
  * Created by iowens on 04/25/19.
  */
 
-public class CompositeServerTransaction extends GattTransaction implements Closeable {
+public class CompositeServerTransaction extends GattServerTransaction implements Closeable {
     public static final String NAME = "CompositeServerTransaction";
-    private List<GattTransaction> transactionList;
+    private List<GattServerTransaction> transactionList;
     private GattTransactionCallback finalCallback;
     private ArrayList<TransactionResult> results = new ArrayList<>();
     private AtomicInteger transactionIndex = new AtomicInteger(0);
     private TransactionQueueController compositeServerQueueController;
 
-    public CompositeServerTransaction(@Nullable GattServerConnection connection, @NonNull List<GattTransaction> transactionList) {
+    public CompositeServerTransaction(@Nullable GattServerConnection connection, @NonNull List<GattServerTransaction> transactionList) {
         super(connection, GattState.IDLE);
         this.transactionList = transactionList;
         // setting the transaction timeout to the aggregate

--- a/src/main/java/com/fitbit/bluetooth/fbgatt/GattServerCallback.java
+++ b/src/main/java/com/fitbit/bluetooth/fbgatt/GattServerCallback.java
@@ -8,6 +8,11 @@
 
 package com.fitbit.bluetooth.fbgatt;
 
+import com.fitbit.bluetooth.fbgatt.btcopies.BluetoothGattCharacteristicCopy;
+import com.fitbit.bluetooth.fbgatt.btcopies.BluetoothGattDescriptorCopy;
+import com.fitbit.bluetooth.fbgatt.util.GattStatus;
+import com.fitbit.bluetooth.fbgatt.util.GattUtils;
+
 import android.bluetooth.BluetoothDevice;
 import android.bluetooth.BluetoothGattCharacteristic;
 import android.bluetooth.BluetoothGattDescriptor;
@@ -19,21 +24,15 @@ import android.os.Build;
 import android.os.Handler;
 import android.os.Looper;
 
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
-import androidx.annotation.VisibleForTesting;
-
-import com.fitbit.bluetooth.fbgatt.btcopies.BluetoothGattCharacteristicCopy;
-import com.fitbit.bluetooth.fbgatt.btcopies.BluetoothGattDescriptorCopy;
-import com.fitbit.bluetooth.fbgatt.util.GattStatus;
-import com.fitbit.bluetooth.fbgatt.util.GattUtils;
-
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.UUID;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.annotation.VisibleForTesting;
 import timber.log.Timber;
 
 /**
@@ -143,17 +142,6 @@ class GattServerCallback extends BluetoothGattServerCallback {
         for (GattServerListener listener : copy) {
             handler.post(() -> listener.onServerServiceAdded(status, service));
         }
-        // if we haven't started up yet, then we'll want to remove these from the services to start
-        handler.post(() -> {
-            if (!FitbitGatt.getInstance().isStarted()) {
-                FitbitGatt.getInstance().removeServiceWithIdFromServicesToAdd(service.getUuid());
-                if (FitbitGatt.getInstance().allServicesStarted()) {
-                    FitbitGatt.getInstance().setStarted();
-                } else {
-                    FitbitGatt.getInstance().addServicesToGattServer();
-                }
-            }
-        });
     }
     // for Characteristics and Descriptors, they are backed by c level objects and the references
     // are passed up to Java via JNI.  This means that the values can change, so we must copy through

--- a/src/main/java/com/fitbit/bluetooth/fbgatt/GattServerConnection.java
+++ b/src/main/java/com/fitbit/bluetooth/fbgatt/GattServerConnection.java
@@ -18,6 +18,8 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.VisibleForTesting;
 
+import java.io.Closeable;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.concurrent.atomic.AtomicLong;
@@ -31,7 +33,7 @@ import timber.log.Timber;
  * Created by iowens on 11/17/17.
  */
 
-public class GattServerConnection {
+public class GattServerConnection implements Closeable {
     private BluetoothGattServer server;
     private TransactionQueueController serverQueue;
     private GattState state;
@@ -280,5 +282,17 @@ public class GattServerConnection {
 
     public Handler getMainHandler() {
         return mainHandler;
+    }
+
+    @Override
+    public void close() {
+        finish();
+    }
+
+    @VisibleForTesting(otherwise = VisibleForTesting.PROTECTED)
+    synchronized void finish() {
+        if(serverQueue != null && !serverQueue.isQueueThreadStopped()) {
+            serverQueue.stop();
+        }
     }
 }

--- a/src/main/java/com/fitbit/bluetooth/fbgatt/TransactionQueueController.java
+++ b/src/main/java/com/fitbit/bluetooth/fbgatt/TransactionQueueController.java
@@ -70,6 +70,7 @@ class TransactionQueueController {
     synchronized void stop(){
         Timber.v("Stopping execution thread");
         stop.compareAndSet(false, true);
+        clearQueue();
         transactionThread.interrupt();
         transactionThread = null;
     }

--- a/src/test/java/com/fitbit/bluetooth/fbgatt/TxPreCommitTests.java
+++ b/src/test/java/com/fitbit/bluetooth/fbgatt/TxPreCommitTests.java
@@ -250,7 +250,7 @@ public class TxPreCommitTests {
         GattServerConnectMockTransaction connect1 = new GattServerConnectMockTransaction(conn, GattState.CONNECTED,  device, false);
         GattServerDisconnectMockTransaction connect2 = new GattServerDisconnectMockTransaction(conn, GattState.DISCONNECTED,  device, false);
         GattServerConnectMockTransaction connect3 = new GattServerConnectMockTransaction(conn, GattState.CONNECTED,  device, false);
-        ArrayList<GattTransaction> transactions = new ArrayList<>(3);
+        ArrayList<GattServerTransaction> transactions = new ArrayList<>(3);
         transactions.add(connect1);
         transactions.add(connect2);
         transactions.add(connect3);
@@ -274,7 +274,7 @@ public class TxPreCommitTests {
         GattServerConnectMockTransaction connect1 = new GattServerConnectMockTransaction(conn, GattState.CONNECTED,  device, false);
         GattServerDisconnectMockTransaction connect2 = new GattServerDisconnectMockTransaction(conn, GattState.DISCONNECTED,  device, true);
         GattServerConnectMockTransaction connect3 = new GattServerConnectMockTransaction(conn, GattState.CONNECTED,  device, false);
-        ArrayList<GattTransaction> transactions = new ArrayList<>(3);
+        ArrayList<GattServerTransaction> transactions = new ArrayList<>(3);
         transactions.add(connect1);
         transactions.add(connect2);
         transactions.add(connect3);


### PR DESCRIPTION
Fixes # If a user toggles bluetooth aggressively the library user may end up clearing services while adding resulting in a stack NPE

### description
It appears that clear can result in an NPE as iterators do not appear
to be in place for android..BluetoothGatt so if you are clearing while
adding it can be a problem ... but that is why bitgatt is designed
around
mutually exclusive transactions, so it was important to wrap the clear
behavior in a tx, that way add and clear can not occur concurrently, at
least
in the library.

### changes
- Updated a few tests related to this issue
- Changed servertx such that it will only take servertx reducing the possibility that a developer may give it client tx instead
- Cleaned up server shutdown such that it will actually stop the thread before releasing
- Tightened up start with services such that it will no longer need to wait for the onServiceAdded callback to decrement, simplifying the behavior around threading and improving readability

### how tested
Tested using Gucci gatt on GS7, GS9+ Exynos, Pixel 3 XL
