### PR TITLE
Busy main looper can ANR

### DIFF
--- a/src/main/java/com/fitbit/bluetooth/fbgatt/FitbitGatt.java
+++ b/src/main/java/com/fitbit/bluetooth/fbgatt/FitbitGatt.java
@@ -16,6 +16,7 @@ import com.fitbit.bluetooth.fbgatt.tx.AddGattServerServiceTransaction;
 import com.fitbit.bluetooth.fbgatt.tx.ClearServerServicesTransaction;
 import com.fitbit.bluetooth.fbgatt.tx.GattConnectTransaction;
 import com.fitbit.bluetooth.fbgatt.util.GattUtils;
+import com.fitbit.bluetooth.fbgatt.util.LooperWatchdog;
 
 import android.annotation.SuppressLint;
 import android.annotation.TargetApi;
@@ -114,7 +115,9 @@ public class FitbitGatt implements PeripheralScanner.TrackerScannerListener, Blu
     @VisibleForTesting
     AtomicBoolean isStarted = new AtomicBoolean(false);
     private Handler connectionCleanup;
-    private HandlerThread gattServerCallbackHandlerThread = new HandlerThread("FitbitGatt Async Operation Thread");
+    private LooperWatchdog asyncOperationThreadWatchdog;
+    // this should be max priority so as to not affect performance
+    private HandlerThread fitbitGattAsyncOperationThread = new HandlerThread("FitbitGatt Async Operation Thread", Thread.MAX_PRIORITY);
     private Handler fitbitGattAsyncOperationHandler;
     private BluetoothRadioStatusListener radioStatusListener;
     @VisibleForTesting
@@ -151,8 +154,11 @@ public class FitbitGatt implements PeripheralScanner.TrackerScannerListener, Blu
         // we will default to one expected device and that it should not looking
         ourInstance.alwaysConnectedScanner = new AlwaysConnectedScanner(1, false, Looper.getMainLooper());
         ourInstance.powerAggregator = new BatteryDataStatsAggregator(null);
-        ourInstance.gattServerCallbackHandlerThread.start();
-        ourInstance.fitbitGattAsyncOperationHandler = new Handler(ourInstance.gattServerCallbackHandlerThread.getLooper());
+        ourInstance.fitbitGattAsyncOperationThread.start();
+        ourInstance.fitbitGattAsyncOperationHandler = new Handler(ourInstance.fitbitGattAsyncOperationThread.getLooper());
+        // we need to make sure that this thread is alive and responsive or our gatt
+        // flow will stop and we won't be able to tell
+        ourInstance.asyncOperationThreadWatchdog = new LooperWatchdog(ourInstance.fitbitGattAsyncOperationThread.getLooper());
     }
 
     @VisibleForTesting
@@ -197,8 +203,8 @@ public class FitbitGatt implements PeripheralScanner.TrackerScannerListener, Blu
      * @return The gatt server handler thread
      */
 
-    public HandlerThread getGattServerCallbackHandlerThread() {
-        return gattServerCallbackHandlerThread;
+    public HandlerThread getFitbitGattAsyncOperationThread() {
+        return fitbitGattAsyncOperationThread;
     }
 
     /**
@@ -804,7 +810,7 @@ public class FitbitGatt implements PeripheralScanner.TrackerScannerListener, Blu
         powerAggregator = new BatteryDataStatsAggregator(context);
         this.appContext = context.getApplicationContext();
         this.serverCallback = new GattServerCallback();
-        this.clientCallback = new GattClientCallback(context);
+        this.clientCallback = new GattClientCallback();
         this.aclListener = new LowEnergyAclListener();
         this.aclListener.register(this.appContext);
         connectionCleanup = new Handler(context.getMainLooper());
@@ -825,6 +831,7 @@ public class FitbitGatt implements PeripheralScanner.TrackerScannerListener, Blu
         addConnectedDevices(context);
         // will start the cleanup process
         decrementAndInvalidateClosedConnections();
+        asyncOperationThreadWatchdog.startProbing();
         return true;
     }
 
@@ -884,6 +891,7 @@ public class FitbitGatt implements PeripheralScanner.TrackerScannerListener, Blu
             radioStatusListener.stopListening();
             radioStatusListener.removeListener();
         }
+        this.asyncOperationThreadWatchdog.stopProbing();
     }
 
     @VisibleForTesting

--- a/src/main/java/com/fitbit/bluetooth/fbgatt/GattClientCallback.java
+++ b/src/main/java/com/fitbit/bluetooth/fbgatt/GattClientCallback.java
@@ -49,18 +49,10 @@ public class GattClientCallback extends BluetoothGattCallback {
     private final List<GattClientListener> listeners;
     private final GattUtils gattUtils = new GattUtils();
 
-    GattClientCallback(@Nullable Context context) {
+    GattClientCallback() {
         super();
         this.listeners = Collections.synchronizedList(new ArrayList<>(4));
-        Looper looper;
-        if(context == null || context.getMainLooper() == null) {
-            Timber.w("[%s] Um.... you really need to provide a non-null context here, things will work, but you'll have an extra thread running around", Build.DEVICE);
-            HandlerThread gattClientCallbackHandlerThread = new HandlerThread("Default Gatt Client Callback Handler Thread", Thread.NORM_PRIORITY);
-            gattClientCallbackHandlerThread.start();
-            looper = gattClientCallbackHandlerThread.getLooper();
-        } else {
-            looper = context.getMainLooper();
-        }
+        Looper looper = FitbitGatt.getInstance().getFitbitGattAsyncOperationThread().getLooper();
         this.handler = new Handler(looper);
     }
 

--- a/src/main/java/com/fitbit/bluetooth/fbgatt/GattServerCallback.java
+++ b/src/main/java/com/fitbit/bluetooth/fbgatt/GattServerCallback.java
@@ -51,7 +51,7 @@ class GattServerCallback extends BluetoothGattServerCallback {
     GattServerCallback() {
         super();
         this.listeners = Collections.synchronizedList(new ArrayList<>(4));
-        Looper looper = FitbitGatt.getInstance().getGattServerCallbackHandlerThread().getLooper();
+        Looper looper = FitbitGatt.getInstance().getFitbitGattAsyncOperationThread().getLooper();
         this.handler = new Handler(looper);
     }
 

--- a/src/main/java/com/fitbit/bluetooth/fbgatt/strategies/BluetoothOffClearGattServerStrategy.java
+++ b/src/main/java/com/fitbit/bluetooth/fbgatt/strategies/BluetoothOffClearGattServerStrategy.java
@@ -60,7 +60,7 @@ public class BluetoothOffClearGattServerStrategy extends Strategy {
         // crash in a stack NPE if the bluetooth service has crashed or is shut down, and we want
         // to make sure that this does not occur on the main thread since this probably transits
         // the JNI and could lead to a ANR
-        Handler strategyHandler = new Handler(FitbitGatt.getInstance().getGattServerCallbackHandlerThread().getLooper());
+        Handler strategyHandler = new Handler(FitbitGatt.getInstance().getFitbitGattAsyncOperationThread().getLooper());
         strategyHandler.post(() -> {
             GattServerConnection serverConn = FitbitGatt.getInstance().getServer();
             if(serverConn == null) {

--- a/src/main/java/com/fitbit/bluetooth/fbgatt/util/LooperWatchdog.java
+++ b/src/main/java/com/fitbit/bluetooth/fbgatt/util/LooperWatchdog.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2019 Fitbit, Inc. All rights reserved.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+package com.fitbit.bluetooth.fbgatt.util;
+
+import android.os.Handler;
+import android.os.Looper;
+import android.os.Message;
+
+import java.util.concurrent.TimeUnit;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.VisibleForTesting;
+import timber.log.Timber;
+
+/**
+ * A class for determining if a provided looper is still responding, will log an error
+ * if it doesn't respond before the typical ANR timeout of 5s.  This class is not suitable
+ * for watching the main thread, though if your main thread isn't responding for longer than
+ * the ANR timeout you should be seeing ANRs rendering any service this class could provide
+ * moot.
+ */
+
+public class LooperWatchdog implements Handler.Callback {
+    /*
+     * The message ID
+     */
+    private static final int MESSAGE_QUEUE_STILL_ALIVE = 25341;
+    /*
+     * The time to wait before logging the stalled state
+     */
+    private static final long TIME_TO_WAIT = TimeUnit.SECONDS.toMillis(4);
+    /*
+     * Time to wait between checks
+     */
+    private static final long TIME_TO_WAIT_BETWEEN_CHECKS = TimeUnit.SECONDS.toMillis(60);
+    /*
+     * The looper that we would like to watch for stalls
+     */
+    private final Handler watchedLooper;
+    // the main looper for scheduling probes
+    private final Handler mainHandler = new Handler(Looper.getMainLooper());
+    /*
+     * The alert runnable for telling us that we are stalled and which HandlerThread it was
+     */
+    private final Runnable alertRunnable = new Runnable() {
+        @Override
+        public void run() {
+            Timber.e(new LooperDeadException(watchedLooper.getLooper()),
+                "Watched Looper, %s not responding quickly, performance impacted.",
+                watchedLooper.getLooper().getThread().getName());
+        }
+    };
+
+    /**
+     * The initializer for the looper watchdog, will take a looper that we would like to watch
+     * @param targetLooper The target looper
+     */
+    public LooperWatchdog(Looper targetLooper) {
+        this.watchedLooper = new Handler(targetLooper, this);
+    }
+
+    /**
+     * Starts the probing of the looper every @{LooperWatchdog#TIME_TO_WAIT_BETWEEN_CHECKS} seconds
+     */
+
+    public void startProbing() {
+        Message message = Message.obtain(watchedLooper);
+        message.what = MESSAGE_QUEUE_STILL_ALIVE;
+        watchedLooper.sendMessage(message);
+        mainHandler.postDelayed(alertRunnable, TIME_TO_WAIT);
+    }
+
+    /**
+     * Will stop probing the looper
+     */
+
+    public void stopProbing(){
+        watchedLooper.removeCallbacksAndMessages(null);
+        mainHandler.removeCallbacksAndMessages(null);
+    }
+
+    @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
+    void continueProbing(){
+        Message message = Message.obtain(watchedLooper);
+        // if we are testing message will be null
+        if(message == null) {
+            message = new Message();
+            message.setTarget(watchedLooper);
+        }
+        message.what = MESSAGE_QUEUE_STILL_ALIVE;
+        watchedLooper.sendMessageDelayed(message, TIME_TO_WAIT_BETWEEN_CHECKS);
+        mainHandler.postDelayed(alertRunnable, TIME_TO_WAIT_BETWEEN_CHECKS + TIME_TO_WAIT);
+    }
+
+    /**
+     * Handles the callback from the target looper that should disarm the alert
+     * @param msg The MSG, probably @{MESSAGE_QUEUE_STILL_ALIVE}
+     * @return True if the message was handled by this subclass, false otherwise
+     */
+
+    @Override
+    public boolean handleMessage(@NonNull Message msg) {
+        switch(msg.what) {
+            case MESSAGE_QUEUE_STILL_ALIVE:
+                // disarm
+                mainHandler.removeCallbacks(alertRunnable);
+                // schedule next
+                continueProbing();
+                break;
+            default:
+                // nothing
+                break;
+        }
+        return true;
+    }
+
+    static class LooperDeadException extends Exception {
+        LooperDeadException(Looper watchedLooper){
+            super("Looper must be dead, no response");
+            this.setStackTrace(watchedLooper.getThread().getStackTrace());
+        }
+    }
+}

--- a/src/test/java/com/fitbit/bluetooth/fbgatt/util/LooperWatchdogTest.java
+++ b/src/test/java/com/fitbit/bluetooth/fbgatt/util/LooperWatchdogTest.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2019 Fitbit, Inc. All rights reserved.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+package com.fitbit.bluetooth.fbgatt.util;
+
+import android.os.Looper;
+import android.os.Message;
+
+import org.junit.Test;
+
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+
+/**
+ * Sadly, it's hard to test loopers & handlers, will build this out further as we go, but I wanted
+ * to make sure that continue is called
+ *
+ * Created by iowens on 10/10/19.
+ */
+
+public class LooperWatchdogTest {
+
+    private static final int MESSAGE_QUEUE_STILL_ALIVE = 25341;
+
+    @Test
+    public void testAlertClearedIfMessageReceived() {
+        Looper mockLooper = mock(Looper.class);
+        LooperWatchdog dog = spy(new LooperWatchdog(mockLooper));
+        Message m = new Message();
+        m.what = MESSAGE_QUEUE_STILL_ALIVE;
+        dog.handleMessage(m);
+        verify(dog, atLeastOnce()).continueProbing();
+    }
+}


### PR DESCRIPTION
Fixes # [Internal Ticket] ANR on broadcast on super-busy main looper

### description
In testing and in production we have seen ANRs that do not look like
ANRs in the log where the main looper is waiting on a lock and the
background thread that is posting to the main looper is also waiting
on the lock.  This leads to a deadlock situation where the main looper's
message queue is waiting on the synchronization barrier while the
message
queue is servicing the next linked work chain ... this chain can get
long while the main looper is waiting on kpoll and then can get stuck
in the while loop for more than the ANR timeout.

The simplest way to fix this is to move the callbacks for events that
occur asynchronously in the gatt client over to a new handler thread and
therefore a new MessageQueue that is far less busy.  This still involves
some overhead, so we will eventually stop using the handlerthread
entirely
and move the implementation to the linked blocking queue as we have
for the outbound events

### changes
- Moved callback events in the GattClientCallback to the dedicated async handlerthread from the main thread
- Added placeholder test
-
-

### how tested
Tested using Gucci test app blast test as well as units and instrumented tests on a Galaxy S9 Exynos on 9 and a Pixel 3 XL on 10
