### PR TITLE
PI scans must be stopped

### DIFF
--- a/src/main/java/com/fitbit/bluetooth/fbgatt/FitbitGatt.java
+++ b/src/main/java/com/fitbit/bluetooth/fbgatt/FitbitGatt.java
@@ -115,6 +115,7 @@ public class FitbitGatt implements PeripheralScanner.TrackerScannerListener, Blu
     @VisibleForTesting
     AtomicBoolean isStarted = new AtomicBoolean(false);
     private Handler connectionCleanup;
+    @Nullable
     private LooperWatchdog asyncOperationThreadWatchdog;
     // this should be max priority so as to not affect performance
     private HandlerThread fitbitGattAsyncOperationThread = new HandlerThread("FitbitGatt Async Operation Thread", Thread.MAX_PRIORITY);
@@ -831,7 +832,9 @@ public class FitbitGatt implements PeripheralScanner.TrackerScannerListener, Blu
         addConnectedDevices(context);
         // will start the cleanup process
         decrementAndInvalidateClosedConnections();
-        asyncOperationThreadWatchdog.startProbing();
+        if(asyncOperationThreadWatchdog != null) {
+            asyncOperationThreadWatchdog.startProbing();
+        }
         return true;
     }
 
@@ -891,7 +894,9 @@ public class FitbitGatt implements PeripheralScanner.TrackerScannerListener, Blu
             radioStatusListener.stopListening();
             radioStatusListener.removeListener();
         }
-        this.asyncOperationThreadWatchdog.stopProbing();
+        if(asyncOperationThreadWatchdog != null) {
+            this.asyncOperationThreadWatchdog.stopProbing();
+        }
     }
 
     @VisibleForTesting


### PR DESCRIPTION
Fixes # Pending intent scan works differently

### description
The pending intent scanner creates a random UUID in the place
of app id since it isn't really our app doing the scanning, this
app id is placed in a scanner map with the pending intent context

It looks like if our app dies and comes back up we could end up wasting
gatt IFs because of how the code is written, so we really must clean up
the existing pending intent scan when we start a new one. We might be
able to do that by cancelling the old one with a newly created PI that
matches the app package and class or the old one.

This fixes the gatt if issue

### changes
- Reconstruct and use the pending intent if it is null as in app was killed and re-launched

### how tested
Guccigatt and on a Pixel 3 XL
