### PR TITLE
Pending intent scan can consume gatt_if

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Fitbit Gatt (Bitgatt) Documentation
+# Fitbit Gatt (Bitgatt) Documentation     [![Build Status](https://travis-ci.com/Fitbit/bitgatt.svg?branch=master)](https://travis-ci.com/Fitbit/bitgatt)
 
 ## Table of Contents
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Fitbit Gatt (Bitgatt) Documentation     [![Build Status](https://travis-ci.com/Fitbit/bitgatt.svg?branch=master)](https://travis-ci.com/Fitbit/bitgatt)
+# Fitbit Gatt (Bitgatt) Documentation
 
 ## Table of Contents
 
@@ -362,6 +362,14 @@ object will keep the scan result with it so that it can be used even if the devi
 The scanner will call a callback if the data changes on a subsequent scan, and will callback when
 started or stopped.  There is a pending intent scan available on Oreo and higher that may be used
 in addition to the low-duty periodical scanner, or with the high-duty scanner.
+
+If you are going to use the pending intent scanner, it is important to ensure that you cancel the scan
+as soon as you can as it consumes an additional gatt_if.  These interfaces are limited in nature and if your application
+is using more than one of them you could inadvertently cause bluetooth to stop working properly on 
+your users' phone.  Bitgatt will prevent you from using more than one additional if, however it would be better
+if you only used a single gatt_if.
+
+If you do not know what a gatt_if is, it is advisable to use the periodical scanner instead.
 
 ## [Always Connected Scanner](#always-connected-scanner)
 


### PR DESCRIPTION
Fixes # internal bug

### description
If a user tries to start a second pending intent scan without first
cancelling an existing pending intent scan bitgatt should try to cancel
it first, even if the process has been newly brought back up.

This should limit the additional gatt_if consumption to only a single
one

### changes
- Pending intent scans will cancel previous pending intent scans
-
-
-

### how tested
Tested with Guccigatt on a Pixel XL 3 on Android 10
