### PR TITLE
Fix Android Stack Crash on Android 7

### DIFF
--- a/src/main/java/com/fitbit/bluetooth/fbgatt/tx/AddGattServerServiceTransaction.java
+++ b/src/main/java/com/fitbit/bluetooth/fbgatt/tx/AddGattServerServiceTransaction.java
@@ -76,7 +76,15 @@ public class AddGattServerServiceTransaction extends GattServerTransaction {
                 getGattServer().setState(GattState.IDLE);
                 return;
             }
-            boolean success = getGattServer().getServer().addService(service);
+            boolean success = false;
+            try {
+                success = getGattServer().getServer().addService(service);
+            } catch ( NullPointerException npe ) {
+                // this is likely due to several reasons, but mostly that the bluetooth service was gone while adding
+                // no reason to make a non-fatal here
+                Timber.i(npe, "There was an internal android stack null pointer exception adding the service, failing");
+                // success still false
+            }
             if(!success) {
                 TransactionResult.Builder builder = new TransactionResult.Builder().transactionName(getName());
                 builder.responseStatus(GattDisconnectReason.getReasonForCode(GattDisconnectReason.GATT_CONN_NO_RESOURCES.getCode()).ordinal());


### PR DESCRIPTION
Fixes # Internal crash when adding services

### description
We thought originally that this crash was caused because
someone could clear services while we were adding
services.  This may have been the case, but we are still
observing crashes on Android 7, as this seems to coincide with
other odd behavior, we are assuming that the bluetooth service has
crashed leading to the internal NPE.

If this is the case it is unlikely that we will be able to handle
these failures by business logic alone.

### changes
- Surrounded with try / catch
-
-
-

### how tested
Tested with unit tests and Pixel 3 XL
