### PR TITLE
Several fixes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,6 +48,7 @@ android {
         release {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+            consumerProguardFile 'proguard-rules.pro'
         }
         debug {
             testCoverageEnabled true

--- a/src/main/java/com/fitbit/bluetooth/fbgatt/FitbitBluetoothDevice.java
+++ b/src/main/java/com/fitbit/bluetooth/fbgatt/FitbitBluetoothDevice.java
@@ -61,7 +61,7 @@ public class FitbitBluetoothDevice {
         this.bluetoothAddress = device.getAddress();
         // this can throw a parcelable null pointer exception down in the stack
         try {
-            this.name = new GattUtils().safeGetBtDeviceName(device);
+            this.name = new GattUtils().debugSafeGetBtDeviceName(device);
         } catch (NullPointerException ex) {
             this.name = "Unknown Device";
         }

--- a/src/main/java/com/fitbit/bluetooth/fbgatt/GattClientCallback.java
+++ b/src/main/java/com/fitbit/bluetooth/fbgatt/GattClientCallback.java
@@ -88,7 +88,7 @@ public class GattClientCallback extends BluetoothGattCallback {
     }
 
     private String getDeviceMacFromGatt(BluetoothGatt gatt) {
-        return gattUtils.safeGetBtDeviceName(gatt);
+        return gattUtils.debugSafeGetBtDeviceName(gatt);
     }
 
     @Override

--- a/src/main/java/com/fitbit/bluetooth/fbgatt/GattServerCallback.java
+++ b/src/main/java/com/fitbit/bluetooth/fbgatt/GattServerCallback.java
@@ -81,7 +81,7 @@ class GattServerCallback extends BluetoothGattServerCallback {
     }
 
     private String getDeviceMacFromDevice(BluetoothDevice device) {
-        return gattUtils.safeGetBtDeviceName(device);
+        return gattUtils.debugSafeGetBtDeviceName(device);
     }
 
     @NonNull Handler getServerCallbackHandler(){

--- a/src/main/java/com/fitbit/bluetooth/fbgatt/GattTransaction.java
+++ b/src/main/java/com/fitbit/bluetooth/fbgatt/GattTransaction.java
@@ -486,7 +486,7 @@ public abstract class GattTransaction extends GattServerCallback implements Gatt
 
     @Override
     public void onServerConnectionStateChange(BluetoothDevice device, int status, int newState) {
-        Timber.v("[%s] onServerConnectionStateChange not handled in tx: %s", utils.safeGetBtDeviceName(device), getName());
+        Timber.v("[%s] onServerConnectionStateChange not handled in tx: %s", utils.debugSafeGetBtDeviceName(device), getName());
     }
 
     @Override
@@ -496,107 +496,107 @@ public abstract class GattTransaction extends GattServerCallback implements Gatt
 
     @Override
     public void onServerCharacteristicReadRequest(BluetoothDevice device, int requestId, int offset, BluetoothGattCharacteristicCopy characteristic) {
-        Timber.v("[%s] onServerCharacteristicReadRequest not handled in tx: %s", utils.safeGetBtDeviceName(device), getName());
+        Timber.v("[%s] onServerCharacteristicReadRequest not handled in tx: %s", utils.debugSafeGetBtDeviceName(device), getName());
     }
 
     @Override
     public void onServerCharacteristicWriteRequest(BluetoothDevice device, int requestId, BluetoothGattCharacteristicCopy characteristic, boolean preparedWrite, boolean responseNeeded, int offset, byte[] value) {
-        Timber.v("[%s] onServerCharacteristicWriteRequest not handled in tx: %s", utils.safeGetBtDeviceName(device), getName());
+        Timber.v("[%s] onServerCharacteristicWriteRequest not handled in tx: %s", utils.debugSafeGetBtDeviceName(device), getName());
     }
 
     @Override
     public void onServerDescriptorReadRequest(BluetoothDevice device, int requestId, int offset, BluetoothGattDescriptorCopy descriptor) {
-        Timber.v("[%s] onServerDescriptorReadRequest not handled in tx: %s", utils.safeGetBtDeviceName(device), getName());
+        Timber.v("[%s] onServerDescriptorReadRequest not handled in tx: %s", utils.debugSafeGetBtDeviceName(device), getName());
     }
 
     @Override
     public void onServerDescriptorWriteRequest(BluetoothDevice device, int requestId, BluetoothGattDescriptorCopy descriptor, boolean preparedWrite, boolean responseNeeded, int offset, byte[] value) {
-        Timber.v("[%s] onServerDescriptorWriteRequest not handled in tx: %s", utils.safeGetBtDeviceName(device), getName());
+        Timber.v("[%s] onServerDescriptorWriteRequest not handled in tx: %s", utils.debugSafeGetBtDeviceName(device), getName());
     }
 
     @Override
     public void onServerExecuteWrite(BluetoothDevice device, int requestId, boolean execute) {
-        Timber.v("[%s] onServerExecuteWrite not handled in tx: %s", utils.safeGetBtDeviceName(device), getName());
+        Timber.v("[%s] onServerExecuteWrite not handled in tx: %s", utils.debugSafeGetBtDeviceName(device), getName());
     }
 
     @Override
     public void onServerNotificationSent(BluetoothDevice device, int status) {
-        Timber.v("[%s] onServerNotificationSent not handled in tx: %s", utils.safeGetBtDeviceName(device), getName());
+        Timber.v("[%s] onServerNotificationSent not handled in tx: %s", utils.debugSafeGetBtDeviceName(device), getName());
     }
 
     @Override
     public void onServerMtuChanged(BluetoothDevice device, int mtu) {
-        Timber.v("[%s] onServerMtuChanged not handled in tx: %s", utils.safeGetBtDeviceName(device), getName());
+        Timber.v("[%s] onServerMtuChanged not handled in tx: %s", utils.debugSafeGetBtDeviceName(device), getName());
     }
 
     @Override
     public void onServerPhyUpdate(BluetoothDevice device, int txPhy, int rxPhy, int status) {
-        Timber.v("[%s] onServerPhyUpdate not handled in tx: %s", utils.safeGetBtDeviceName(device), getName());
+        Timber.v("[%s] onServerPhyUpdate not handled in tx: %s", utils.debugSafeGetBtDeviceName(device), getName());
     }
 
     @Override
     public void onServerPhyRead(BluetoothDevice device, int txPhy, int rxPhy, int status) {
-        Timber.v("[%s] onServerPhyRead not handled in tx: %s", utils.safeGetBtDeviceName(device), getName());
+        Timber.v("[%s] onServerPhyRead not handled in tx: %s", utils.debugSafeGetBtDeviceName(device), getName());
     }
 
     @Override
     public void onPhyUpdate(BluetoothGatt gatt, int txPhy, int rxPhy, int status) {
-        Timber.v("[%s] onPhyUpdate not handled in tx: %s", utils.safeGetBtDeviceName(gatt), getName());
+        Timber.v("[%s] onPhyUpdate not handled in tx: %s", utils.debugSafeGetBtDeviceName(gatt), getName());
     }
 
     @Override
     public void onPhyRead(BluetoothGatt gatt, int txPhy, int rxPhy, int status) {
-        Timber.v("[%s] onPhyRead not handled in tx: %s", utils.safeGetBtDeviceName(gatt), getName());
+        Timber.v("[%s] onPhyRead not handled in tx: %s", utils.debugSafeGetBtDeviceName(gatt), getName());
     }
 
     @Override
     public void onConnectionStateChange(BluetoothGatt gatt, int status, int newState) {
-        Timber.v("[%s] onPhyRead not handled in tx: %s", utils.safeGetBtDeviceName(gatt), getName());
+        Timber.v("[%s] onPhyRead not handled in tx: %s", utils.debugSafeGetBtDeviceName(gatt), getName());
     }
 
     @Override
     public void onServicesDiscovered(BluetoothGatt gatt, int status) {
-        Timber.v("[%s] onServicesDiscovered not handled in tx: %s", utils.safeGetBtDeviceName(gatt), getName());
+        Timber.v("[%s] onServicesDiscovered not handled in tx: %s", utils.debugSafeGetBtDeviceName(gatt), getName());
     }
 
     @Override
     public void onCharacteristicRead(BluetoothGatt gatt, BluetoothGattCharacteristicCopy characteristic, int status) {
-        Timber.v("[%s] onCharacteristicRead not handled in tx: %s", utils.safeGetBtDeviceName(gatt), getName());
+        Timber.v("[%s] onCharacteristicRead not handled in tx: %s", utils.debugSafeGetBtDeviceName(gatt), getName());
     }
 
     @Override
     public void onCharacteristicWrite(BluetoothGatt gatt, BluetoothGattCharacteristicCopy characteristic, int status) {
-        Timber.v("[%s] onCharacteristicWrite not handled in tx: %s", utils.safeGetBtDeviceName(gatt), getName());
+        Timber.v("[%s] onCharacteristicWrite not handled in tx: %s", utils.debugSafeGetBtDeviceName(gatt), getName());
     }
 
     @Override
     public void onCharacteristicChanged(BluetoothGatt gatt, BluetoothGattCharacteristicCopy characteristic) {
-        Timber.v("[%s] onCharacteristicChanged not handled in tx: %s", utils.safeGetBtDeviceName(gatt), getName());
+        Timber.v("[%s] onCharacteristicChanged not handled in tx: %s", utils.debugSafeGetBtDeviceName(gatt), getName());
     }
 
     @Override
     public void onDescriptorRead(BluetoothGatt gatt, BluetoothGattDescriptorCopy descriptor, int status) {
-        Timber.v("[%s] onDescriptorRead not handled in tx: %s", utils.safeGetBtDeviceName(gatt), getName());
+        Timber.v("[%s] onDescriptorRead not handled in tx: %s", utils.debugSafeGetBtDeviceName(gatt), getName());
     }
 
     @Override
     public void onDescriptorWrite(BluetoothGatt gatt, BluetoothGattDescriptorCopy descriptor, int status) {
-        Timber.v("[%s] onDescriptorWrite not handled in tx: %s", utils.safeGetBtDeviceName(gatt), getName());
+        Timber.v("[%s] onDescriptorWrite not handled in tx: %s", utils.debugSafeGetBtDeviceName(gatt), getName());
     }
 
     @Override
     public void onReliableWriteCompleted(BluetoothGatt gatt, int status) {
-        Timber.v("[%s] onReliableWriteCompleted not handled in tx: %s", utils.safeGetBtDeviceName(gatt), getName());
+        Timber.v("[%s] onReliableWriteCompleted not handled in tx: %s", utils.debugSafeGetBtDeviceName(gatt), getName());
     }
 
     @Override
     public void onReadRemoteRssi(BluetoothGatt gatt, int rssi, int status) {
-        Timber.v("[%s] onReadRemoteRssi not handled in tx: %s", utils.safeGetBtDeviceName(gatt), getName());
+        Timber.v("[%s] onReadRemoteRssi not handled in tx: %s", utils.debugSafeGetBtDeviceName(gatt), getName());
     }
 
     @Override
     public void onMtuChanged(BluetoothGatt gatt, int mtu, int status) {
-        Timber.v("[%s] onMtuChanged not handled in tx: %s", utils.safeGetBtDeviceName(gatt), getName());
+        Timber.v("[%s] onMtuChanged not handled in tx: %s", utils.debugSafeGetBtDeviceName(gatt), getName());
     }
 
     /**

--- a/src/main/java/com/fitbit/bluetooth/fbgatt/tools/GattPlugin.java
+++ b/src/main/java/com/fitbit/bluetooth/fbgatt/tools/GattPlugin.java
@@ -2112,7 +2112,7 @@ public class GattPlugin implements DumperPlugin, FitbitGatt.FitbitGattCallback, 
                     default:
                         type = "unknown";
                 }
-                String deviceName = new GattUtils().safeGetBtDeviceName(device);
+                String deviceName = new GattUtils().debugSafeGetBtDeviceName(device);
                 String deviceAddress = device.getAddress();
                 String origin = clientConnections.get(mac).getDevice().getOrigin().name();
                 String rssi = String.valueOf(clientConnections.get(mac).getDevice().getRssi());
@@ -2191,7 +2191,7 @@ public class GattPlugin implements DumperPlugin, FitbitGatt.FitbitGattCallback, 
                     default:
                         type = "unknown";
                 }
-                String deviceName = new GattUtils().safeGetBtDeviceName(device);
+                String deviceName = new GattUtils().debugSafeGetBtDeviceName(device);
                 String deviceAddress = device.getAddress();
                 String origin = clientConnections.get(mac).getDevice().getOrigin().name();
                 String rssi = String.valueOf(clientConnections.get(mac).getDevice().getRssi());

--- a/src/main/java/com/fitbit/bluetooth/fbgatt/util/GattUtils.java
+++ b/src/main/java/com/fitbit/bluetooth/fbgatt/util/GattUtils.java
@@ -8,6 +8,7 @@
 
 package com.fitbit.bluetooth.fbgatt.util;
 
+import com.fitbit.bluetooth.fbgatt.BuildConfig;
 import com.fitbit.bluetooth.fbgatt.btcopies.BluetoothGattCharacteristicCopy;
 import com.fitbit.bluetooth.fbgatt.btcopies.BluetoothGattDescriptorCopy;
 import com.fitbit.bluetooth.fbgatt.btcopies.BluetoothGattServiceCopy;
@@ -190,22 +191,27 @@ public class GattUtils {
      * Protect against NPEs while getting the bluetooth device name if we suspect that it might
      * not be set on the remote peripheral
      *
+     * In release this method will return  "Unknown Name".
+     *
      * @param localGatt The {@link BluetoothGatt} instance
      * @return The device name or "unknown" if null
      */
-
-    public String safeGetBtDeviceName(@Nullable BluetoothGatt localGatt) {
-        try {
-            if (localGatt == null || localGatt.getDevice() == null) {
-                throw new NullPointerException("The device was null inside of the gatt");
+    public String debugSafeGetBtDeviceName(@Nullable BluetoothGatt localGatt) {
+        //The problem with accessing this is that it may not be cached on some phones
+        // resulting a long blocking operation
+        if(BuildConfig.DEBUG) {
+            try {
+                if (localGatt == null || localGatt.getDevice() == null) {
+                    throw new NullPointerException("The device was null inside of the gatt");
+                }
+                String btName = localGatt.getDevice().getName();
+                if (btName != null) {
+                    return btName;
+                }
+            } catch (NullPointerException ex) {
+                // https://fabric.io/fitbit7/android/apps/com.fitbit.fitbitmobile/issues/5a9637c68cb3c2fa63fa1333?time=last-seven-days
+                Timber.e(ex, "get name internal to the gatt failed with an Parcel Read Exception NPE");
             }
-            String btName = localGatt.getDevice().getName();
-            if (btName != null) {
-                return btName;
-            }
-        } catch (NullPointerException ex) {
-            // https://fabric.io/fitbit7/android/apps/com.fitbit.fitbitmobile/issues/5a9637c68cb3c2fa63fa1333?time=last-seven-days
-            Timber.e(ex, "get name internal to the gatt failed with an Parcel Read Exception NPE");
         }
         return "Unknown Name";
     }
@@ -218,7 +224,7 @@ public class GattUtils {
      * @return The device name or "unknown" if null
      */
 
-    public String safeGetBtDeviceName(@Nullable BluetoothDevice device) {
+    public String debugSafeGetBtDeviceName(@Nullable BluetoothDevice device) {
         try {
             if (device == null) {
                 throw new NullPointerException("The device was null inside of the gatt");

--- a/src/test/java/com/fitbit/bluetooth/fbgatt/BluetoothUtilsTest.java
+++ b/src/test/java/com/fitbit/bluetooth/fbgatt/BluetoothUtilsTest.java
@@ -60,37 +60,37 @@ public class BluetoothUtilsTest {
 
     @Test
     public void testProvidingGattWithNullDevice() throws Exception {
-        String name = utils.safeGetBtDeviceName(mockGatt);
+        String name = utils.debugSafeGetBtDeviceName(mockGatt);
         Assert.assertEquals("Unknown Name", name);
     }
 
     @Test
     public void testProvidingBluetoothDeviceWithNullName() throws Exception {
-        String name = utils.safeGetBtDeviceName(mockDevice);
+        String name = utils.debugSafeGetBtDeviceName(mockDevice);
         Assert.assertEquals("Unknown Name", name);
     }
 
     @Test
     public void testProvidingGattWithNonNullName() throws Exception {
-        String name = utils.safeGetBtDeviceName(nonNullMockGatt);
+        String name = utils.debugSafeGetBtDeviceName(nonNullMockGatt);
         Assert.assertEquals("Ionic", name);
     }
 
     @Test
     public void testProvidingBluetoothDeviceWithNonNullName() throws Exception {
-        String name = utils.safeGetBtDeviceName(nonNullMockDevice);
+        String name = utils.debugSafeGetBtDeviceName(nonNullMockDevice);
         Assert.assertEquals("Ionic", name);
     }
 
     @Test
     public void testThrowableOnGetNameInsideGatt() throws Exception {
-        String name = utils.safeGetBtDeviceName(throwableNullMockGatt);
+        String name = utils.debugSafeGetBtDeviceName(throwableNullMockGatt);
         Assert.assertEquals("Unknown Name", name);
     }
 
     @Test
     public void testThrowableOnGetNameInsideBluetoothDevice() throws Exception {
-        String name = utils.safeGetBtDeviceName(throwableNullMockDevice);
+        String name = utils.debugSafeGetBtDeviceName(throwableNullMockDevice);
         Assert.assertEquals("Unknown Name", name);
     }
 }


### PR DESCRIPTION
Fixes:

1. Exposes consumer proguard files
2. Switch to a ConcurrentHashMap instead for maintaining the list of listeners to avooid race conditions
3. Moved add connected devices to fitbitGattAsyncOperationHandler as it can lead to ANRs
4. Accessing the GattUtils().safeGetBtDeviceName was resulting in ANR and it same cases in crashes as the system was no longer to post new messages to the handler

Tested manualy 
