### PR TITLE
Fix the race condition in transaction queue start() call

### DIFF
--- a/src/main/java/com/fitbit/bluetooth/fbgatt/GattServerCallback.java
+++ b/src/main/java/com/fitbit/bluetooth/fbgatt/GattServerCallback.java
@@ -119,6 +119,9 @@ class GattServerCallback extends BluetoothGattServerCallback {
 
                     break;
                 case BluetoothProfile.STATE_CONNECTED:
+                    if (gattConnection == null) {
+                        FitbitGatt.getInstance().addConnectedDevice(device);
+                    }
                     for (ServerConnectionEventListener asyncListener : conn.getConnectionEventListeners()) {
                         // since this is async, the result status is irrelevant so it will always be
                         // success because we received this data
@@ -127,10 +130,6 @@ class GattServerCallback extends BluetoothGattServerCallback {
                                 .responseStatus(status)
                                 .resultStatus(TransactionResult.TransactionResultStatus.SUCCESS).build();
                         handler.post(() -> asyncListener.onServerConnectionStateChanged(device, result, conn));
-                    }
-
-                    if (gattConnection == null) {
-                        FitbitGatt.getInstance().addConnectedDevice(device);
                     }
 
                     break;

--- a/src/main/java/com/fitbit/bluetooth/fbgatt/TransactionQueueController.java
+++ b/src/main/java/com/fitbit/bluetooth/fbgatt/TransactionQueueController.java
@@ -42,22 +42,22 @@ class TransactionQueueController {
         transactionQueue.add(tx);
     }
 
-
     void clearQueue() {
         transactionQueue.clear();
     }
 
     @VisibleForTesting
     synchronized void start() {
-        Timber.v("Starting execution thread");
-        stopped.compareAndSet(true, false);
-        if (transactionThread != null) {
-            transactionThread.interrupt();
-            transactionThread = null;
+        if (stopped.compareAndSet(true, false)) {
+            Timber.v("Starting execution thread");
+            if (transactionThread != null) {
+                transactionThread.interrupt();
+                transactionThread = null;
+            }
+            transactionThread = new ClientThread(threadName);
+            transactionThread.setPriority(Thread.MAX_PRIORITY);
+            transactionThread.start();
         }
-        transactionThread = new ClientThread(threadName);
-        transactionThread.setPriority(Thread.MAX_PRIORITY);
-        transactionThread.start();
     }
 
     synchronized void stop() {


### PR DESCRIPTION
Fixes #

### description
Resolve the race condition on start() call
This is the side effect of this PR. Before this [PR#26](https://github.com/Fitbit/bitgatt/pull/26/), we used to call start() before queueTransaction().

### changes
- change queueTransaction() as synchronized call to prevent from triggering multiple TransactionQueueController.start() calls.
- Also a minor tweak for onConnectionStateChange 

### how tested
Added new android test case and verified we don't invoke start queue multiple times.
