### PR TITLE
Fix Stale Bluetooth enabled status and unit test updates

### DIFF
--- a/src/androidTest/java/com/fitbit/bluetooth/fbgatt/BitgattLeScannerTest.java
+++ b/src/androidTest/java/com/fitbit/bluetooth/fbgatt/BitgattLeScannerTest.java
@@ -1,0 +1,58 @@
+/*
+ *  Copyright 2020 Fitbit, Inc. All rights reserved.
+ *
+ *  This Source Code Form is subject to the terms of the Mozilla Public
+ *  License, v. 2.0. If a copy of the MPL was not distributed with this
+ *  file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+package com.fitbit.bluetooth.fbgatt;
+
+import com.fitbit.bluetooth.fbgatt.util.BluetoothUtils;
+
+import android.bluetooth.BluetoothAdapter;
+import android.bluetooth.le.BluetoothLeScanner;
+import android.content.Context;
+
+import org.junit.Test;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import androidx.test.platform.app.InstrumentationRegistry;
+
+import static org.junit.Assert.*;
+
+/**
+ * Instrumentation test to play with scanner references
+ * At the time of this commit these tests pass
+ */
+public class BitgattLeScannerTest {
+
+    private Context context = InstrumentationRegistry.getInstrumentation().getContext();
+    private BluetoothUtils bluetoothUtils = new BluetoothUtils();
+
+    @Test
+    public void testScannerConsistency() throws InterruptedException {
+        BluetoothAdapter adapter = bluetoothUtils.getBluetoothAdapter(context);
+        CountDownLatch cdl = new CountDownLatch(1);
+        assert adapter != null;
+        adapter.enable();
+
+        cdl.await(1, TimeUnit.SECONDS);
+        BluetoothLeScanner scanner = adapter.getBluetoothLeScanner();
+
+        assertNotNull(scanner);
+
+        assertSame(scanner, adapter.getBluetoothLeScanner());
+
+        adapter.disable();
+        cdl.await(1, TimeUnit.SECONDS);
+
+
+        adapter.enable();
+        cdl.await(1, TimeUnit.SECONDS);
+
+        assertSame(scanner, adapter.getBluetoothLeScanner());
+    }
+}

--- a/src/androidTest/java/com/fitbit/bluetooth/fbgatt/GattServerTests.java
+++ b/src/androidTest/java/com/fitbit/bluetooth/fbgatt/GattServerTests.java
@@ -14,7 +14,7 @@ import com.fitbit.bluetooth.fbgatt.tx.ReadGattServerCharacteristicDescriptorValu
 import com.fitbit.bluetooth.fbgatt.tx.ReadGattServerCharacteristicValueTransaction;
 import com.fitbit.bluetooth.fbgatt.tx.mocks.MockNoOpTransaction;
 import com.fitbit.bluetooth.fbgatt.tx.mocks.NotifyGattServerCharacteristicMockTransaction;
-import com.fitbit.bluetooth.fbgatt.util.GattUtils;
+import com.fitbit.bluetooth.fbgatt.util.BluetoothUtils;
 import com.fitbit.bluetooth.fbgatt.util.NoOpGattCallback;
 
 import android.bluetooth.BluetoothAdapter;
@@ -235,7 +235,7 @@ public class GattServerTests {
     public void btOffOnWillClearServicesAndThatGattServerIfStartedWillRetunrAfterToggle() throws InterruptedException {
         // should do nothing if already started
         final CountDownLatch cdl = new CountDownLatch(2);
-        BluetoothAdapter adapter = new GattUtils().getBluetoothAdapter(mockContext);
+        BluetoothAdapter adapter = new BluetoothUtils().getBluetoothAdapter(mockContext);
         assertNotNull("adapter is null", adapter);
         AtomicBoolean isFirst = new AtomicBoolean(true);
         FitbitGatt.FitbitGattCallback cb = new NoOpGattCallback() {
@@ -277,7 +277,7 @@ public class GattServerTests {
     public void btOffOnWillClearServicesAndThatGattServerIsStillUsable() throws InterruptedException {
         // should do nothing if already started
         final CountDownLatch cdl = new CountDownLatch(2);
-        BluetoothAdapter adapter = new GattUtils().getBluetoothAdapter(mockContext);
+        BluetoothAdapter adapter = new BluetoothUtils().getBluetoothAdapter(mockContext);
         assertNotNull("adapter is null", adapter);
         AtomicBoolean isFirst = new AtomicBoolean(true);
         FitbitGatt.FitbitGattCallback cb = new NoOpGattCallback() {
@@ -326,7 +326,7 @@ public class GattServerTests {
     public void btOffOnWillClearServicesAndThatGattServerIfStartedWillRetunrAfterToggleMultipleTimesInQuickSuccession() throws InterruptedException {
         // should do nothing if already started
         final CountDownLatch cdl = new CountDownLatch(2);
-        BluetoothAdapter adapter = new GattUtils().getBluetoothAdapter(mockContext);
+        BluetoothAdapter adapter = new BluetoothUtils().getBluetoothAdapter(mockContext);
         assertNotNull("adapter is null", adapter);
         AtomicBoolean isFirst = new AtomicBoolean(true);
         AtomicInteger countTest = new AtomicInteger(1);

--- a/src/main/java/com/fitbit/bluetooth/fbgatt/BitGattDependencyProvider.java
+++ b/src/main/java/com/fitbit/bluetooth/fbgatt/BitGattDependencyProvider.java
@@ -10,6 +10,8 @@
 
 package com.fitbit.bluetooth.fbgatt;
 
+import com.fitbit.bluetooth.fbgatt.util.BluetoothManagerProvider;
+import com.fitbit.bluetooth.fbgatt.util.BluetoothUtils;
 import com.fitbit.bluetooth.fbgatt.util.GattUtils;
 
 import android.app.PendingIntent;
@@ -33,6 +35,14 @@ class BitGattDependencyProvider {
 
     GattUtils getNewGattUtils() {
         return new GattUtils();
+    }
+
+    BluetoothUtils getBluetoothUtils() {
+        return new BluetoothUtils();
+    }
+
+    BluetoothManagerProvider getBluetoothManagerProvider() {
+        return new BluetoothManagerProvider();
     }
 
     LowEnergyAclListener getNewLowEnergyAclListener() {

--- a/src/main/java/com/fitbit/bluetooth/fbgatt/BluetoothRadioStatusListener.java
+++ b/src/main/java/com/fitbit/bluetooth/fbgatt/BluetoothRadioStatusListener.java
@@ -8,7 +8,7 @@
 
 package com.fitbit.bluetooth.fbgatt;
 
-import com.fitbit.bluetooth.fbgatt.util.GattUtils;
+import com.fitbit.bluetooth.fbgatt.util.BluetoothUtils;
 
 import android.bluetooth.BluetoothAdapter;
 import android.content.BroadcastReceiver;
@@ -18,8 +18,8 @@ import android.content.IntentFilter;
 import android.os.Handler;
 import android.os.Looper;
 import android.os.SystemClock;
-import androidx.annotation.VisibleForTesting;
 
+import androidx.annotation.VisibleForTesting;
 import timber.log.Timber;
 
 /**
@@ -173,7 +173,8 @@ class BluetoothRadioStatusListener {
 
     BluetoothRadioStatusListener(Context context, boolean shouldInitializeListening) {
         this.context = context;
-        BluetoothAdapter adapter = new GattUtils().getBluetoothAdapter(context);
+        BluetoothUtils bluetoothUtils = new BluetoothUtils();
+        BluetoothAdapter adapter = bluetoothUtils.getBluetoothAdapter(context);
         // if we are in this condition, something is seriously wrong
         this.currentState = (adapter != null) ? adapter.getState() : BluetoothAdapter.STATE_OFF;
         // this handler is to deliver the callbacks in the same way as they would usually

--- a/src/main/java/com/fitbit/bluetooth/fbgatt/FitbitGatt.java
+++ b/src/main/java/com/fitbit/bluetooth/fbgatt/FitbitGatt.java
@@ -22,6 +22,7 @@ import com.fitbit.bluetooth.fbgatt.tx.AddGattServerServiceTransaction;
 import com.fitbit.bluetooth.fbgatt.tx.ClearServerServicesTransaction;
 import com.fitbit.bluetooth.fbgatt.tx.GattConnectTransaction;
 import com.fitbit.bluetooth.fbgatt.util.LooperWatchdog;
+
 import android.annotation.SuppressLint;
 import android.annotation.TargetApi;
 import android.app.PendingIntent;
@@ -42,6 +43,7 @@ import android.os.Handler;
 import android.os.HandlerThread;
 import android.os.Looper;
 import android.os.ParcelUuid;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -54,6 +56,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+
 import androidx.annotation.MainThread;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -187,8 +190,7 @@ public class FitbitGatt implements PeripheralScanner.TrackerScannerListener, Blu
             Timber.w("Bitgatt must not be started yet, so as far as we know BT is off.");
             return false;
         }
-        BluetoothAdapter adapter = dependencyProvider.getNewGattUtils().getBluetoothAdapter(appContext);
-        if (adapter == null || !adapter.isEnabled()) {
+        if (!dependencyProvider.getBluetoothUtils().isBluetoothEnabled(appContext)) {
             if (isBluetoothOn) {
                 isBluetoothOn = false;
             }
@@ -803,7 +805,7 @@ public class FitbitGatt implements PeripheralScanner.TrackerScannerListener, Blu
     @VisibleForTesting
     void addConnectedDeviceToConnectionMap(Context context, FitbitBluetoothDevice device) {
         Timber.v("Adding the new connected device");
-        BluetoothAdapter adapter = dependencyProvider.getNewGattUtils().getBluetoothAdapter(context);
+        BluetoothAdapter adapter = dependencyProvider.getBluetoothUtils().getBluetoothAdapter(context);
         if (adapter != null) {
             if (null == connectionMap.get(device)) {
                 Timber.v("Adding connected device named %s, with address %s", device.getName(), device.getAddress());
@@ -1426,7 +1428,7 @@ public class FitbitGatt implements PeripheralScanner.TrackerScannerListener, Blu
      * @param callback The async callback for resolving the gatt server open
      */
     private synchronized void startServer(OpenGattServerCallback callback) {
-        BluetoothManager manager = dependencyProvider.getNewGattUtils().getBluetoothManager(this.appContext);
+        BluetoothManager manager = dependencyProvider.getBluetoothManagerProvider().get(this.appContext);
         if (manager != null && manager.getAdapter() != null) {
             /*
              * We've observed that the registration of the callback inside of the android

--- a/src/main/java/com/fitbit/bluetooth/fbgatt/HandleIntentBasedScanResult.java
+++ b/src/main/java/com/fitbit/bluetooth/fbgatt/HandleIntentBasedScanResult.java
@@ -9,7 +9,7 @@
 package com.fitbit.bluetooth.fbgatt;
 
 import com.fitbit.bluetooth.fbgatt.exception.BitGattStartException;
-import com.fitbit.bluetooth.fbgatt.util.GattUtils;
+import com.fitbit.bluetooth.fbgatt.util.BluetoothUtils;
 import com.fitbit.bluetooth.fbgatt.util.ScanFailedReason;
 
 import android.annotation.TargetApi;
@@ -25,13 +25,14 @@ import android.os.Build;
 import java.util.List;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.VisibleForTesting;
 import timber.log.Timber;
 
 /**
  * It is important to remember that this class may be instantiated by the system, and we may
  * have been dead in the background, so no assumptions about runtime state should be made
  * by any calls herein.
- *
+ * <p>
  * This class needs to be public because we receive this as a global broadcast. Why can't we dynamically
  * register the receiver for this? Because dynamically registered receivers are only valid for as long
  * as their contexts are valid, if the app dies so does the receiver unless registered in the manifest,
@@ -41,147 +42,45 @@ import timber.log.Timber;
 public class HandleIntentBasedScanResult extends BroadcastReceiver {
 
 
+    private final BluetoothUtils bluetoothUtils;
+    private final FitbitGatt fitbitGatt;
+
+    public HandleIntentBasedScanResult() {
+        this(
+            new BluetoothUtils(),
+            FitbitGatt.getInstance()
+        );
+    }
+
+    @VisibleForTesting
+    HandleIntentBasedScanResult(BluetoothUtils bluetoothUtils, FitbitGatt fitbitGatt) {
+        this.bluetoothUtils = bluetoothUtils;
+        this.fitbitGatt = fitbitGatt;
+    }
+
     @TargetApi(Build.VERSION_CODES.O)
     @Override
     public void onReceive(Context context, Intent intent) {
         if (intent != null) {
             // need to use the adapter directly because bitgatt may not have been instantiated
-            BluetoothAdapter adapter = new GattUtils().getBluetoothAdapter(context);
-            if(adapter == null || !adapter.isEnabled()) {
-                Timber.w("Bluetooth is turned off, ignoring");
+            if (!hasBluetoothAdapterEnabled(context)) {
                 return;
             }
-            if (!FitbitGatt.getInstance().isInitialized()) {
+
+            if (!fitbitGatt.isInitialized()) {
                 Timber.v("Bitgatt wasn't started, starting before handling...");
             }
+
             Timber.v("Received connection update : %s", intent.getAction());
             // added by the system to the intent defined in {@link OreoBackgroundScanner#explicitIntentHelper}
             int callbackType = intent.getIntExtra(BluetoothLeScanner.EXTRA_CALLBACK_TYPE, ScanSettings.CALLBACK_TYPE_FIRST_MATCH);
             // added by the system to the intent defined in {@link OreoBackgroundScanner#explicitIntentHelper}
             int errorCode = intent.getIntExtra(BluetoothLeScanner.EXTRA_ERROR_CODE, ScanFailedReason.SCAN_SUCCESS_NO_ERROR.getCode());
+
             if (errorCode == ScanFailedReason.SCAN_SUCCESS_NO_ERROR.getCode()) {
                 // added by the system to the intent defined in {@link OreoBackgroundScanner#explicitIntentHelper}
                 List<ScanResult> results = intent.getParcelableArrayListExtra(BluetoothLeScanner.EXTRA_LIST_SCAN_RESULT);
-                if (results != null && !results.isEmpty()) {
-                    // there are callback results, so now we should do something with this, it's
-                    // not OK to do this on the main thread so we'll jump onto a scheduler
-                    for(ScanResult result : results) {
-                        GattClientCallback callbackClient = FitbitGatt.getInstance().getClientCallback();
-                        if (callbackClient != null) {
-                            callbackClient.getClientCallbackHandler().post(() -> {
-                                FitbitBluetoothDevice fitBd = new FitbitBluetoothDevice(result.getDevice());
-                                fitBd.setScanRecord(result.getScanRecord());
-                                fitBd.origin = FitbitBluetoothDevice.DeviceOrigin.SCANNED;
-                                fitBd.setRssi(result.getRssi());
-                                /*
-                                 * If bitgatt is started, then we need to determine whether we are still
-                                 * pending intent scanning from a different start and set the correct
-                                 * state internally.  If we are not started, then is pending intent scanning
-                                 * will be false because the scanner will have been null, so the next scan event
-                                 * we will enter is started and is pending intent scanning false, so we will
-                                 * update the state.
-                                 */
-                                if (FitbitGatt.getInstance().isInitialized()) {
-                                    if (FitbitGatt.getInstance().isPendingIntentScanning()) {
-                                        Timber.v("Bitgatt is started and scanning, so we should add %s", fitBd);
-                                        FitbitGatt.getInstance().addBackgroundScannedDeviceConnection(fitBd);
-                                    } else {
-                                        Timber.v("Bitgatt is started, but is not intent scanning, so we may have died in the background adding %s and telling bitgatt that we are still intent scanning", fitBd);
-                                        PeripheralScanner scanner = FitbitGatt.getInstance().getPeripheralScanner();
-                                        if (scanner != null) {
-                                            scanner.setIsPendingIntentScanning(true);
-                                        } else {
-                                            Timber.v("Tried to handle the event and update the scanner's internal state, but the scanner was null");
-                                        }
-                                        FitbitGatt.getInstance().addBackgroundScannedDeviceConnection(fitBd);
-                                    }
-                                } else {
-                                    Timber.w("Bitgatt is not started, or we aren't pending intent scanning, let's try starting for %s", fitBd);
-                                    // this will take us off of the main thread
-                                    FitbitGatt.getInstance().registerGattEventListener(new FitbitGatt.FitbitGattCallback() {
-                                        @Override
-                                        public void onBluetoothPeripheralDiscovered(@NonNull GattConnection connection) {
-                                            //no-op
-                                        }
-
-                                        @Override
-                                        public void onBluetoothPeripheralDisconnected(@NonNull GattConnection connection) {
-                                            //no-op
-                                        }
-
-
-                                        @Override
-                                        public void onScanStarted() {
-                                            //no-op
-                                        }
-
-                                        @Override
-                                        public void onScanStopped() {
-                                            //no-op
-                                        }
-
-                                        @Override
-                                        public void onScannerInitError(BitGattStartException error) {
-                                            //no-op
-                                        }
-
-                                        @Override
-                                        public void onPendingIntentScanStopped() {
-                                            //no-op
-                                        }
-
-                                        @Override
-                                        public void onPendingIntentScanStarted() {
-                                            //no-op
-                                        }
-
-                                        @Override
-                                        public void onBluetoothOff() {
-                                            //no-op
-                                        }
-
-                                        @Override
-                                        public void onBluetoothOn() {
-                                            //no-op
-                                        }
-
-                                        @Override
-                                        public void onBluetoothTurningOn() {
-                                            //no-op
-                                        }
-
-                                        @Override
-                                        public void onBluetoothTurningOff() {
-                                            //no-op
-                                        }
-
-                                        @Override
-                                        public void onGattServerStarted(GattServerConnection serverConnection) {
-                                            //no-op
-                                        }
-
-                                        @Override
-                                        public void onGattServerStartError(BitGattStartException error) {
-                                            //no-op
-                                        }
-
-                                        @Override
-                                        public void onGattClientStarted() {
-                                            //no-op
-                                        }
-
-                                        @Override
-                                        public void onGattClientStartError(BitGattStartException error) {
-                                            //no-op
-                                        }
-                                    });
-                                }
-                            });
-                        }
-                    }
-                } else {
-                    Timber.w("Scan callback with no results");
-                }
+                processResults(results);
             } else {
                 Timber.v("There was an error in the background scan of ScanCallback.SCAN_FAILED_* const type %s", ScanFailedReason.getReasonForCode(errorCode));
                 Timber.v("The callback type was ScanSettings.CALLBACK_TYPE_* %d", callbackType);
@@ -190,4 +89,157 @@ public class HandleIntentBasedScanResult extends BroadcastReceiver {
             Timber.v("The intent service was started with a null intent.  We are probably initializing");
         }
     }
+
+    private void processResults(List<ScanResult> results) {
+        if (results != null && !results.isEmpty()) {
+            // there are callback results, so now we should do something with this, it's
+            // not OK to do this on the main thread so we'll jump onto a scheduler
+            for (ScanResult result : results) {
+                GattClientCallback callbackClient = fitbitGatt.getClientCallback();
+                if (callbackClient != null) {
+                    callbackClient.getClientCallbackHandler().post(() -> {
+                        addDevice(getFitbitBluetoothDevice(result));
+                    });
+                }
+            }
+        } else {
+            Timber.w("Scan callback with no results");
+        }
+    }
+
+    private void addDevice(FitbitBluetoothDevice fitbitBluetoothDevice) {
+        /*
+         * If bitgatt is started, then we need to determine whether we are still
+         * pending intent scanning from a different start and set the correct
+         * state internally.  If we are not started, then is pending intent scanning
+         * will be false because the scanner will have been null, so the next scan event
+         * we will enter is started and is pending intent scanning false, so we will
+         * update the state.
+         */
+        if (fitbitGatt.isInitialized()) {
+            addToBitGatt(fitbitBluetoothDevice);
+        } else {
+            Timber.w("Bitgatt is not started, or we aren't pending intent scanning, let's try starting for %s", fitbitBluetoothDevice);
+            // this will take us off of the main thread
+            fitbitGatt.registerGattEventListener(new HandleIntentGattCallback(fitbitBluetoothDevice));
+        }
+    }
+
+    private void addToBitGatt(FitbitBluetoothDevice fitbitBluetoothDevice) {
+        if (fitbitGatt.isPendingIntentScanning()) {
+            Timber.v("Bitgatt is started and scanning, so we should add %s", fitbitBluetoothDevice);
+        } else {
+            Timber.v("Bitgatt is started, but is not intent scanning, so we may have died in the background adding %s and telling bitgatt that we are still intent scanning", fitbitBluetoothDevice);
+            PeripheralScanner scanner = fitbitGatt.getPeripheralScanner();
+            if (scanner != null) {
+                scanner.setIsPendingIntentScanning(true);
+            } else {
+                Timber.v("Tried to handle the event and update the scanner's internal state, but the scanner was null");
+            }
+        }
+        fitbitGatt.addBackgroundScannedDeviceConnection(fitbitBluetoothDevice);
+    }
+
+    @NonNull
+    private FitbitBluetoothDevice getFitbitBluetoothDevice(ScanResult result) {
+        FitbitBluetoothDevice fitbitBluetoothDevice = new FitbitBluetoothDevice(result.getDevice());
+        fitbitBluetoothDevice.setScanRecord(result.getScanRecord());
+        fitbitBluetoothDevice.origin = FitbitBluetoothDevice.DeviceOrigin.SCANNED;
+        fitbitBluetoothDevice.setRssi(result.getRssi());
+        return fitbitBluetoothDevice;
+    }
+
+    private boolean hasBluetoothAdapterEnabled(Context context) {
+        return bluetoothUtils.isBluetoothEnabled(context);
+    }
+
+
+    private class HandleIntentGattCallback implements FitbitGatt.FitbitGattCallback {
+
+
+        private FitbitBluetoothDevice device;
+
+        HandleIntentGattCallback(FitbitBluetoothDevice device) {
+            this.device = device;
+        }
+
+        @Override
+        public void onBluetoothPeripheralDiscovered(@NonNull GattConnection connection) {
+            //no-op
+        }
+
+        @Override
+        public void onBluetoothPeripheralDisconnected(@NonNull GattConnection connection) {
+            //no-op
+        }
+
+
+        @Override
+        public void onScanStarted() {
+            //no-op
+        }
+
+        @Override
+        public void onScanStopped() {
+            //no-op
+        }
+
+        @Override
+        public void onScannerInitError(BitGattStartException error) {
+            //no-op
+        }
+
+        @Override
+        public void onPendingIntentScanStopped() {
+            //no-op
+        }
+
+        @Override
+        public void onPendingIntentScanStarted() {
+            //no-op
+        }
+
+        @Override
+        public void onBluetoothOff() {
+            //no-op
+        }
+
+        @Override
+        public void onBluetoothOn() {
+            //no-op
+        }
+
+        @Override
+        public void onBluetoothTurningOn() {
+            //no-op
+        }
+
+        @Override
+        public void onBluetoothTurningOff() {
+            //no-op
+        }
+
+        @Override
+        public void onGattServerStarted(GattServerConnection serverConnection) {
+            //no-op
+        }
+
+        @Override
+        public void onGattServerStartError(BitGattStartException error) {
+            //no-op
+        }
+
+        @Override
+        public void onGattClientStarted() {
+            addToBitGatt(device);
+            //we added the device we unregister the callback
+            fitbitGatt.unregisterGattEventListener(this);
+        }
+
+        @Override
+        public void onGattClientStartError(BitGattStartException error) {
+            //no-op
+        }
+    }
+
 }

--- a/src/main/java/com/fitbit/bluetooth/fbgatt/PeripheralScanner.java
+++ b/src/main/java/com/fitbit/bluetooth/fbgatt/PeripheralScanner.java
@@ -8,6 +8,7 @@
 
 package com.fitbit.bluetooth.fbgatt;
 
+import com.fitbit.bluetooth.fbgatt.util.BluetoothUtils;
 import com.fitbit.bluetooth.fbgatt.util.GattUtils;
 
 import android.annotation.TargetApi;
@@ -76,7 +77,7 @@ class PeripheralScanner {
     AtomicBoolean periodicalScanEnabled;
     private ScanCallback callback;
     private TrackerScannerListener listener;
-    private GattUtils bleUtils;
+    private BluetoothUtils bleUtils;
     private boolean instrumentationTestMode;
 
     private Map<String, BluetoothDevice> foundDevices = new HashMap<>();
@@ -117,7 +118,7 @@ class PeripheralScanner {
         // we can just run this every 30s, if the caller doesn't do anything wrong it should never
         // exceed five ... once it gets to 4 don't let the user start another one
         mHandler.postDelayed(resetScanCounter, SCAN_TOO_MUCH_WARN_INTERVAL);
-        bleUtils = new GattUtils();
+        bleUtils = new BluetoothUtils();
         scanner = new BitgattLeScanner(context);
         callback = new ScanCallback() {
             @Override
@@ -639,7 +640,7 @@ class PeripheralScanner {
                 return null;
             }
 
-            if (!scanner.isBluetoothEnabled()) {
+            if (!bleUtils.isBluetoothEnabled(context)) {
                 Timber.w("Scanner cannot be started when Bluetooth is off");
                 listener.onPendingIntentScanStatusChanged(pendingIntentIsScanning.get());
                 return null;

--- a/src/main/java/com/fitbit/bluetooth/fbgatt/tx/CloseGattServerTransaction.java
+++ b/src/main/java/com/fitbit/bluetooth/fbgatt/tx/CloseGattServerTransaction.java
@@ -14,9 +14,8 @@ import com.fitbit.bluetooth.fbgatt.GattServerTransaction;
 import com.fitbit.bluetooth.fbgatt.GattState;
 import com.fitbit.bluetooth.fbgatt.GattTransactionCallback;
 import com.fitbit.bluetooth.fbgatt.TransactionResult;
-import com.fitbit.bluetooth.fbgatt.util.GattUtils;
+import com.fitbit.bluetooth.fbgatt.util.BluetoothUtils;
 
-import android.bluetooth.BluetoothAdapter;
 import android.bluetooth.BluetoothGattServer;
 
 import timber.log.Timber;
@@ -59,8 +58,8 @@ public class CloseGattServerTransaction extends GattServerTransaction {
                 getGattServer().setState(GattState.IDLE);
             });
         } else {
-            BluetoothAdapter adapter = new GattUtils().getBluetoothAdapter(FitbitGatt.getInstance().getAppContext());
-            if(adapter != null && adapter.isEnabled()) {
+            BluetoothUtils bluetoothUtils = new BluetoothUtils();
+            if(bluetoothUtils.isBluetoothEnabled(FitbitGatt.getInstance().getAppContext())) {
                 Timber.e("I hope you know what you are doing, you will not be able to operate on the gatt server again until BT is toggled.");
             }
             try {

--- a/src/main/java/com/fitbit/bluetooth/fbgatt/tx/mocks/BlockingServerTaskTestMockTransaction.java
+++ b/src/main/java/com/fitbit/bluetooth/fbgatt/tx/mocks/BlockingServerTaskTestMockTransaction.java
@@ -8,8 +8,6 @@
 
 package com.fitbit.bluetooth.fbgatt.tx.mocks;
 
-import android.bluetooth.BluetoothGattCharacteristic;
-
 import com.fitbit.bluetooth.fbgatt.FitbitGatt;
 import com.fitbit.bluetooth.fbgatt.GattConnection;
 import com.fitbit.bluetooth.fbgatt.GattServerConnection;
@@ -17,7 +15,9 @@ import com.fitbit.bluetooth.fbgatt.GattState;
 import com.fitbit.bluetooth.fbgatt.GattTransaction;
 import com.fitbit.bluetooth.fbgatt.GattTransactionCallback;
 import com.fitbit.bluetooth.fbgatt.TransactionResult;
-import com.fitbit.bluetooth.fbgatt.util.GattUtils;
+import com.fitbit.bluetooth.fbgatt.util.BluetoothUtils;
+
+import android.bluetooth.BluetoothGattCharacteristic;
 
 import java.util.Objects;
 
@@ -39,10 +39,10 @@ public class BlockingServerTaskTestMockTransaction extends GattTransaction {
     protected void transaction(GattTransactionCallback callback) {
         super.transaction(callback);
         // let's do something useful with the adapter
-        GattUtils utils = new GattUtils();
+        BluetoothUtils bluetoothUtils = new BluetoothUtils();
         boolean is2MsymSupported = false;
         if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.O) {
-            is2MsymSupported = Objects.requireNonNull(utils.getBluetoothAdapter(FitbitGatt.getInstance().getAppContext())).isLe2MPhySupported();
+            is2MsymSupported = Objects.requireNonNull(bluetoothUtils.getBluetoothAdapter(FitbitGatt.getInstance().getAppContext())).isLe2MPhySupported();
         }
         Timber.i("2 msym is supported? %b", is2MsymSupported);
         startTime = System.currentTimeMillis();

--- a/src/main/java/com/fitbit/bluetooth/fbgatt/tx/mocks/BlockingTaskTestMockTransaction.java
+++ b/src/main/java/com/fitbit/bluetooth/fbgatt/tx/mocks/BlockingTaskTestMockTransaction.java
@@ -16,6 +16,7 @@ import com.fitbit.bluetooth.fbgatt.GattState;
 import com.fitbit.bluetooth.fbgatt.GattTransaction;
 import com.fitbit.bluetooth.fbgatt.GattTransactionCallback;
 import com.fitbit.bluetooth.fbgatt.TransactionResult;
+import com.fitbit.bluetooth.fbgatt.util.BluetoothUtils;
 import com.fitbit.bluetooth.fbgatt.util.GattUtils;
 
 import java.util.Objects;
@@ -38,10 +39,10 @@ public class BlockingTaskTestMockTransaction extends GattTransaction {
     protected void transaction(GattTransactionCallback callback) {
         super.transaction(callback);
         // let's do something useful with the adapter
-        GattUtils utils = new GattUtils();
+        BluetoothUtils bluetoothUtils = new BluetoothUtils();
         boolean is2MsymSupported = false;
         if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.O) {
-            is2MsymSupported = Objects.requireNonNull(utils.getBluetoothAdapter(FitbitGatt.getInstance().getAppContext())).isLe2MPhySupported();
+            is2MsymSupported = Objects.requireNonNull(bluetoothUtils.getBluetoothAdapter(FitbitGatt.getInstance().getAppContext())).isLe2MPhySupported();
         }
         Timber.i("2 msym is supported? %b", is2MsymSupported);
         startTime = System.currentTimeMillis();

--- a/src/main/java/com/fitbit/bluetooth/fbgatt/tx/mocks/TimeoutTestMockTransaction.java
+++ b/src/main/java/com/fitbit/bluetooth/fbgatt/tx/mocks/TimeoutTestMockTransaction.java
@@ -13,8 +13,7 @@ import com.fitbit.bluetooth.fbgatt.GattConnection;
 import com.fitbit.bluetooth.fbgatt.GattState;
 import com.fitbit.bluetooth.fbgatt.GattTransaction;
 import com.fitbit.bluetooth.fbgatt.GattTransactionCallback;
-import com.fitbit.bluetooth.fbgatt.TransactionResult;
-import com.fitbit.bluetooth.fbgatt.util.GattUtils;
+import com.fitbit.bluetooth.fbgatt.util.BluetoothUtils;
 
 import android.bluetooth.BluetoothGattCharacteristic;
 
@@ -41,10 +40,10 @@ public class TimeoutTestMockTransaction extends GattTransaction {
     protected void transaction(GattTransactionCallback callback) {
         super.transaction(callback);
         // let's do something useful with the adapter
-        GattUtils utils = new GattUtils();
+        BluetoothUtils bluetoothUtils = new BluetoothUtils();
         boolean is2MsymSupported = false;
         if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.O) {
-            is2MsymSupported = Objects.requireNonNull(utils.getBluetoothAdapter(FitbitGatt.getInstance().getAppContext())).isLe2MPhySupported();
+            is2MsymSupported = Objects.requireNonNull(bluetoothUtils.getBluetoothAdapter(FitbitGatt.getInstance().getAppContext())).isLe2MPhySupported();
         }
         Timber.i("2 msym is supported? %b", is2MsymSupported);
         // this transaction is designed to timeout to ensure that it blocks the execution thread

--- a/src/main/java/com/fitbit/bluetooth/fbgatt/util/BluetoothManagerProvider.java
+++ b/src/main/java/com/fitbit/bluetooth/fbgatt/util/BluetoothManagerProvider.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2019 Fitbit, Inc. All rights reserved.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+package com.fitbit.bluetooth.fbgatt.util;
+
+import android.bluetooth.BluetoothManager;
+import android.content.Context;
+
+import androidx.annotation.Nullable;
+
+/**
+ * Provides {@link android.bluetooth.BluetoothManager}
+ */
+public class BluetoothManagerProvider {
+
+    /**
+     * Get the {@link android.bluetooth.BluetoothManager}, will return null if Bluetooth feature not available
+     */
+    @Nullable
+    public BluetoothManager get(Context context) {
+        return (BluetoothManager) context.getSystemService(Context.BLUETOOTH_SERVICE);
+    }
+}

--- a/src/main/java/com/fitbit/bluetooth/fbgatt/util/BluetoothUtils.java
+++ b/src/main/java/com/fitbit/bluetooth/fbgatt/util/BluetoothUtils.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2019 Fitbit, Inc. All rights reserved.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+package com.fitbit.bluetooth.fbgatt.util;
+
+import android.bluetooth.BluetoothAdapter;
+import android.bluetooth.BluetoothManager;
+import android.bluetooth.le.BluetoothLeScanner;
+import android.content.Context;
+
+import androidx.annotation.Nullable;
+
+/**
+ * Bluetooth Utils
+ */
+public class BluetoothUtils {
+
+    private final BluetoothManagerProvider bluetoothManagerProvider;
+
+    public BluetoothUtils() {
+        this(new BluetoothManagerProvider());
+    }
+
+    BluetoothUtils(BluetoothManagerProvider bluetoothManagerProvider) {
+        this.bluetoothManagerProvider = bluetoothManagerProvider;
+    }
+
+    /**
+     * Will fetch the bluetooth adapter or return null if it's not available
+     *
+     * @param context The android context
+     * @return The bluetooth adapter or null
+     */
+    @Nullable
+    public BluetoothAdapter getBluetoothAdapter(Context context) {
+        BluetoothManager manager = bluetoothManagerProvider.get(context);
+        if (manager == null) {
+            return null;
+        }
+        return manager.getAdapter();
+    }
+
+    /**
+     * Returns a {@link BluetoothLeScanner} object for Bluetooth LE scan operations.
+     */
+    @Nullable
+    public BluetoothLeScanner getBluetoothLeScanner(Context context) {
+        BluetoothAdapter adapter = getBluetoothAdapter(context);
+        // Normally we should not check if ble is enabled due to the underlying implementation
+        // which check for bluetooth state. This is added to ensure consistency on all OEM's
+        if (adapter == null || !isBluetoothEnabled(context)) {
+            return null;
+        }
+        return adapter.getBluetoothLeScanner();
+    }
+
+    /**
+     * Return true if Bluetooth is currently enabled and ready for use.
+     *
+     * @return true if the local adapter is turned on
+     */
+    public boolean isBluetoothEnabled(Context context) {
+        BluetoothAdapter adapter = getBluetoothAdapter(context);
+        if (adapter == null) {
+            return false;
+        }
+        return adapter.isEnabled();
+    }
+}

--- a/src/main/java/com/fitbit/bluetooth/fbgatt/util/GattUtils.java
+++ b/src/main/java/com/fitbit/bluetooth/fbgatt/util/GattUtils.java
@@ -22,8 +22,10 @@ import android.bluetooth.BluetoothGattService;
 import android.bluetooth.BluetoothManager;
 import android.bluetooth.BluetoothProfile;
 import android.content.Context;
+
 import java.util.Arrays;
 import java.util.List;
+
 import androidx.annotation.Nullable;
 import timber.log.Timber;
 
@@ -73,8 +75,10 @@ public class GattUtils {
      *
      * @param context The android context
      * @return The bluetooth adapter or null
+     *
+     * @deprecated see {{@link BluetoothUtils}}
      */
-
+    @Deprecated
     public @Nullable
     BluetoothAdapter getBluetoothAdapter(Context context) {
         BluetoothManager manager = getBluetoothManager(context);
@@ -88,6 +92,7 @@ public class GattUtils {
         return adapter;
     }
 
+    @Deprecated
     public @Nullable
     BluetoothManager getBluetoothManager(Context context) {
         return (BluetoothManager) context.getSystemService(Context.BLUETOOTH_SERVICE);

--- a/src/test/java/com/fitbit/bluetooth/fbgatt/AlwaysConnectedScannerTest.java
+++ b/src/test/java/com/fitbit/bluetooth/fbgatt/AlwaysConnectedScannerTest.java
@@ -8,10 +8,9 @@
 
 package com.fitbit.bluetooth.fbgatt;
 
-import com.fitbit.bluetooth.fbgatt.util.GattUtils;
+import com.fitbit.bluetooth.fbgatt.util.BluetoothUtils;
 import com.fitbit.bluetooth.fbgatt.util.LooperWatchdog;
 
-import android.bluetooth.BluetoothAdapter;
 import android.bluetooth.le.ScanFilter;
 import android.content.Context;
 import android.content.Intent;
@@ -65,9 +64,8 @@ public class AlwaysConnectedScannerTest {
         }
         return true;
     };
-    private GattUtils utilsMock = mock(GattUtils.class);
+    private BluetoothUtils utilsMock = mock(BluetoothUtils.class);
     private LowEnergyAclListener lowEnergyAclListenerMock = mock(LowEnergyAclListener.class);
-    private BluetoothAdapter adapterMock = mock(BluetoothAdapter.class);
     private BluetoothRadioStatusListener bluetoothRadioStatusListenerMock = mock(BluetoothRadioStatusListener.class);
     private BitGattDependencyProvider dependencyProviderMock = mock(BitGattDependencyProvider.class);
 
@@ -81,11 +79,10 @@ public class AlwaysConnectedScannerTest {
         FitbitGatt.setInstance(null); // It seems another test is influencing this one. Haven't yet pinpointed witch one. This fixes the issue.
         doReturn(mockContext).when(mockContext).getApplicationContext();
         doReturn(bluetoothRadioStatusListenerMock).when(dependencyProviderMock).getNewBluetoothRadioStatusListener(mockContext, false);
-        doReturn(utilsMock).when(dependencyProviderMock).getNewGattUtils();
+        doReturn(utilsMock).when(dependencyProviderMock).getBluetoothUtils();
         doReturn(lowEnergyAclListenerMock).when(dependencyProviderMock).getNewLowEnergyAclListener();
-        doReturn(adapterMock).when(utilsMock).getBluetoothAdapter(mockContext);
         doCallRealMethod().when(dependencyProviderMock).getNewPeripheralScanner(eq(mockContext), any());
-        doReturn(true).when(adapterMock).isEnabled();
+        doReturn(true).when(utilsMock).isBluetoothEnabled(mockContext);
 
         Looper mockMainThreadLooper = mock(Looper.class);
         Thread mockMainThread = mock(Thread.class);

--- a/src/test/java/com/fitbit/bluetooth/fbgatt/BitgattLeScannerTest.java
+++ b/src/test/java/com/fitbit/bluetooth/fbgatt/BitgattLeScannerTest.java
@@ -1,0 +1,176 @@
+/*
+ *  Copyright 2020 Fitbit, Inc. All rights reserved.
+ *
+ *  This Source Code Form is subject to the terms of the Mozilla Public
+ *  License, v. 2.0. If a copy of the MPL was not distributed with this
+ *  file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+package com.fitbit.bluetooth.fbgatt;
+
+import com.fitbit.bluetooth.fbgatt.util.BluetoothUtils;
+
+import android.app.PendingIntent;
+import android.bluetooth.le.BluetoothLeScanner;
+import android.bluetooth.le.ScanCallback;
+import android.bluetooth.le.ScanFilter;
+import android.bluetooth.le.ScanSettings;
+import android.content.Context;
+import android.os.Build;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+public class BitgattLeScannerTest {
+
+    private Context contextMock = mock(Context.class);
+    private BluetoothLeScanner scannerMock = mock(BluetoothLeScanner.class);
+    private BluetoothUtils mockBluetoothUtils = mock(BluetoothUtils.class);
+    private BitgattLeScanner sut;
+
+    @Before
+    public void before() {
+        doReturn(scannerMock).when(mockBluetoothUtils).getBluetoothLeScanner(contextMock);
+        doReturn(true).when(mockBluetoothUtils).isBluetoothEnabled(contextMock);
+        sut = new BitgattLeScanner(contextMock, mockBluetoothUtils);
+    }
+
+    @Test
+    public void testStartScanner() {
+        ScanCallback cb = mock(ScanCallback.class);
+        sut.startScan(cb);
+        verify(scannerMock).startScan(cb);
+    }
+
+    @Test
+    public void testStartScannerWithSettingsAndFilters() {
+        ScanCallback cb = mock(ScanCallback.class);
+        ScanSettings settings = mock(ScanSettings.class);
+        List<ScanFilter> filters = new ArrayList<>();
+        sut.startScan(filters, settings, cb);
+        verify(scannerMock, never()).startScan(cb);
+        verify(scannerMock).startScan(filters, settings, cb);
+    }
+
+    @Test
+    public void testStartScannerWithSettingsAndFiltersPI() throws NoSuchFieldException, IllegalAccessException {
+        new TestUtils().setStaticField(Build.VERSION.class.getField("SDK_INT"), Build.VERSION_CODES.O);
+        ScanSettings settings = mock(ScanSettings.class);
+        List<ScanFilter> filters = new ArrayList<>();
+        PendingIntent intent = mock(PendingIntent.class);
+        sut.startScan(filters, settings, intent);
+        verify(scannerMock).startScan(filters, settings, intent);
+    }
+
+    @Test
+    public void testStartScannerWithSettingsAndFiltersPIPreOreo() throws NoSuchFieldException, IllegalAccessException {
+        new TestUtils().setStaticField(Build.VERSION.class.getField("SDK_INT"), Build.VERSION_CODES.N);
+        ScanSettings settings = mock(ScanSettings.class);
+        List<ScanFilter> filters = new ArrayList<>();
+        PendingIntent intent = mock(PendingIntent.class);
+        sut.startScan(filters, settings, intent);
+        verify(scannerMock, never()).startScan(filters, settings, intent);
+    }
+
+    @Test
+    public void stopScanBtEnabledWithCB() {
+        ScanCallback cb = mock(ScanCallback.class);
+        sut.stopScan(cb);
+        verify(scannerMock).stopScan(cb);
+    }
+
+    @Test
+    public void stopScanBtEnabledWithPI() throws NoSuchFieldException, IllegalAccessException {
+        new TestUtils().setStaticField(Build.VERSION.class.getField("SDK_INT"), Build.VERSION_CODES.O);
+        PendingIntent pi = mock(PendingIntent.class);
+        sut.stopScan(pi);
+        verify(scannerMock).stopScan(pi);
+    }
+
+    @Test
+    public void stopScanBtEnabledWithPreOreo() throws NoSuchFieldException, IllegalAccessException {
+        new TestUtils().setStaticField(Build.VERSION.class.getField("SDK_INT"), Build.VERSION_CODES.N);
+        PendingIntent pi = mock(PendingIntent.class);
+        sut.stopScan(pi);
+        verify(scannerMock, never()).stopScan(pi);
+    }
+
+    @Test
+    public void testFlushPendingScanResults() throws NoSuchFieldException, IllegalAccessException {
+        ScanCallback cb = mock(ScanCallback.class);
+        sut.flushPendingScanResults(cb);
+        verify(scannerMock).flushPendingScanResults(cb);
+    }
+
+    @Test
+    public void testNoScannerNoExceptions() throws NoSuchFieldException, IllegalAccessException {
+        new TestUtils().setStaticField(Build.VERSION.class.getField("SDK_INT"), Build.VERSION_CODES.O);
+        doReturn(null).when(mockBluetoothUtils).getBluetoothLeScanner(contextMock);
+
+        BitgattLeScanner sut = new BitgattLeScanner(contextMock, mockBluetoothUtils);
+
+        ScanCallback cb = mock(ScanCallback.class);
+        ScanSettings settings = mock(ScanSettings.class);
+        List<ScanFilter> filters = new ArrayList<>();
+        PendingIntent intent = mock(PendingIntent.class);
+
+        sut.startScan(cb);
+        sut.startScan(filters, settings, cb);
+        sut.startScan(filters, settings, intent);
+        sut.stopScan(cb);
+        sut.stopScan(intent);
+        sut.flushPendingScanResults(cb);
+
+        verify(mockBluetoothUtils, times(6)).getBluetoothLeScanner(contextMock);
+        verifyNoMoreInteractions(scannerMock);
+    }
+
+    @Test
+    public void testNoAdapterNoExceptions() throws NoSuchFieldException, IllegalAccessException {
+        new TestUtils().setStaticField(Build.VERSION.class.getField("SDK_INT"), Build.VERSION_CODES.O);
+
+        BitgattLeScanner sut = new BitgattLeScanner(contextMock, mockBluetoothUtils);
+
+        ScanCallback cb = mock(ScanCallback.class);
+        ScanSettings settings = mock(ScanSettings.class);
+        List<ScanFilter> filters = new ArrayList<>();
+        PendingIntent intent = mock(PendingIntent.class);
+        sut.startScan(cb);
+        sut.startScan(filters, settings, cb);
+        sut.startScan(filters, settings, intent);
+        sut.stopScan(cb);
+        sut.stopScan(intent);
+        sut.flushPendingScanResults(cb);
+        assertTrue(sut.isBluetoothEnabled());
+    }
+
+    @Test
+    public void testNoContext() throws NoSuchFieldException, IllegalAccessException {
+        new TestUtils().setStaticField(Build.VERSION.class.getField("SDK_INT"), Build.VERSION_CODES.O);
+
+        BitgattLeScanner sut = new BitgattLeScanner(null);
+
+        ScanCallback cb = mock(ScanCallback.class);
+        ScanSettings settings = mock(ScanSettings.class);
+        List<ScanFilter> filters = new ArrayList<>();
+        PendingIntent intent = mock(PendingIntent.class);
+        sut.startScan(cb);
+        sut.startScan(filters, settings, cb);
+        sut.startScan(filters, settings, intent);
+        sut.stopScan(cb);
+        sut.stopScan(intent);
+        sut.flushPendingScanResults(cb);
+        assertFalse(sut.isBluetoothEnabled());
+    }
+}

--- a/src/test/java/com/fitbit/bluetooth/fbgatt/CompositeClientTransactionTests.java
+++ b/src/test/java/com/fitbit/bluetooth/fbgatt/CompositeClientTransactionTests.java
@@ -9,10 +9,9 @@
 package com.fitbit.bluetooth.fbgatt;
 
 import com.fitbit.bluetooth.fbgatt.tx.mocks.WriteGattCharacteristicMockTransaction;
-import com.fitbit.bluetooth.fbgatt.util.GattUtils;
+import com.fitbit.bluetooth.fbgatt.util.BluetoothUtils;
 import com.fitbit.bluetooth.fbgatt.util.LooperWatchdog;
 
-import android.bluetooth.BluetoothAdapter;
 import android.bluetooth.BluetoothDevice;
 import android.bluetooth.BluetoothGattCharacteristic;
 import android.content.Context;
@@ -33,7 +32,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
@@ -70,9 +69,8 @@ public class CompositeClientTransactionTests {
 
     @Before
     public void before() {
-        GattUtils utilsMock = mock(GattUtils.class);
+        BluetoothUtils utilsMock = mock(BluetoothUtils.class);
         LowEnergyAclListener lowEnergyAclListenerMock = mock(LowEnergyAclListener.class);
-        BluetoothAdapter adapterMock = mock(BluetoothAdapter.class);
         BluetoothRadioStatusListener bluetoothRadioStatusListenerMock = mock(BluetoothRadioStatusListener.class);
         BitGattDependencyProvider dependencyProviderMock = mock(BitGattDependencyProvider.class);
         Context mockContext = mock(Context.class);
@@ -80,10 +78,9 @@ public class CompositeClientTransactionTests {
         when(mockContext.getSystemService(Any.class)).thenReturn(null);
         when(mockContext.getApplicationContext()).thenReturn(mockContext);
         doReturn(bluetoothRadioStatusListenerMock).when(dependencyProviderMock).getNewBluetoothRadioStatusListener(any(), eq(false));
-        doReturn(utilsMock).when(dependencyProviderMock).getNewGattUtils();
+        doReturn(utilsMock).when(dependencyProviderMock).getBluetoothUtils();
         doReturn(lowEnergyAclListenerMock).when(dependencyProviderMock).getNewLowEnergyAclListener();
-        doReturn(adapterMock).when(utilsMock).getBluetoothAdapter(mockContext);
-        doReturn(true).when(adapterMock).isEnabled();
+        doReturn(true).when(utilsMock).isBluetoothEnabled(mockContext);
 
         Looper mockMainThreadLooper = mock(Looper.class);
         Thread mockMainThread = mock(Thread.class);

--- a/src/test/java/com/fitbit/bluetooth/fbgatt/GattServerTests.java
+++ b/src/test/java/com/fitbit/bluetooth/fbgatt/GattServerTests.java
@@ -12,7 +12,8 @@ import com.fitbit.bluetooth.fbgatt.btcopies.BluetoothGattCharacteristicCopy;
 import com.fitbit.bluetooth.fbgatt.btcopies.BluetoothGattDescriptorCopy;
 import com.fitbit.bluetooth.fbgatt.tx.mocks.AddGattServerServiceMockTransaction;
 import com.fitbit.bluetooth.fbgatt.tx.mocks.SendGattServerResponseMockTransaction;
-import com.fitbit.bluetooth.fbgatt.util.GattUtils;
+import com.fitbit.bluetooth.fbgatt.util.BluetoothManagerProvider;
+import com.fitbit.bluetooth.fbgatt.util.BluetoothUtils;
 import com.fitbit.bluetooth.fbgatt.util.LooperWatchdog;
 
 import android.bluetooth.BluetoothAdapter;
@@ -20,6 +21,7 @@ import android.bluetooth.BluetoothDevice;
 import android.bluetooth.BluetoothGatt;
 import android.bluetooth.BluetoothGattServer;
 import android.bluetooth.BluetoothGattService;
+import android.bluetooth.BluetoothManager;
 import android.content.Context;
 import android.os.Handler;
 import android.os.Looper;
@@ -47,20 +49,23 @@ public class GattServerTests {
 
     @Before
     public void before(){
-        GattUtils utilsMock = mock(GattUtils.class);
+        BluetoothUtils utilsMock = mock(BluetoothUtils.class);
         LowEnergyAclListener lowEnergyAclListenerMock = mock(LowEnergyAclListener.class);
         BluetoothAdapter adapterMock = mock(BluetoothAdapter.class);
         BluetoothRadioStatusListener bluetoothRadioStatusListenerMock = mock(BluetoothRadioStatusListener.class);
         BitGattDependencyProvider dependencyProviderMock = mock(BitGattDependencyProvider.class);
         Context mockContext = mock(Context.class);
+        BluetoothManager managerMock = mock(BluetoothManager.class);
+        BluetoothManagerProvider mockBluetoothManagerProvider = mock(BluetoothManagerProvider.class);
 
         when(mockContext.getSystemService(Any.class)).thenReturn(null);
         when(mockContext.getApplicationContext()).thenReturn(mockContext);
         doReturn(bluetoothRadioStatusListenerMock).when(dependencyProviderMock).getNewBluetoothRadioStatusListener(mockContext, false);
-        doReturn(utilsMock).when(dependencyProviderMock).getNewGattUtils();
+        doReturn(utilsMock).when(dependencyProviderMock).getBluetoothUtils();
         doReturn(lowEnergyAclListenerMock).when(dependencyProviderMock).getNewLowEnergyAclListener();
-        doReturn(adapterMock).when(utilsMock).getBluetoothAdapter(mockContext);
-        doReturn(true).when(adapterMock).isEnabled();
+        doReturn(true).when(utilsMock).isBluetoothEnabled(mockContext);
+        doReturn(mockBluetoothManagerProvider).when(dependencyProviderMock).getBluetoothManagerProvider();
+        doReturn(managerMock).when(mockBluetoothManagerProvider).get(mockContext);
 
         Handler mockHandler = mock(Handler.class);
         Looper mockLooper = mock(Looper.class);

--- a/src/test/java/com/fitbit/bluetooth/fbgatt/HandleIntentBasedScanResultTest.java
+++ b/src/test/java/com/fitbit/bluetooth/fbgatt/HandleIntentBasedScanResultTest.java
@@ -1,0 +1,370 @@
+/*
+ *  Copyright 2020 Fitbit, Inc. All rights reserved.
+ *
+ *  This Source Code Form is subject to the terms of the Mozilla Public
+ *  License, v. 2.0. If a copy of the MPL was not distributed with this
+ *  file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+package com.fitbit.bluetooth.fbgatt;
+
+import com.fitbit.bluetooth.fbgatt.util.BluetoothUtils;
+import com.fitbit.bluetooth.fbgatt.util.ScanFailedReason;
+
+import android.bluetooth.BluetoothAdapter;
+import android.bluetooth.BluetoothDevice;
+import android.bluetooth.le.BluetoothLeScanner;
+import android.bluetooth.le.ScanRecord;
+import android.bluetooth.le.ScanResult;
+import android.bluetooth.le.ScanSettings;
+import android.content.Context;
+import android.content.Intent;
+import android.os.Handler;
+
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+public class HandleIntentBasedScanResultTest {
+
+    private BluetoothUtils mockBluetoothUtils = mock(BluetoothUtils.class);
+    private FitbitGatt fitbitGattMock = mock(FitbitGatt.class);
+
+    private HandleIntentBasedScanResult sut = new HandleIntentBasedScanResult(mockBluetoothUtils, fitbitGattMock);
+
+    private Context contextMock = mock(Context.class);
+    private Intent intentMock = mock(Intent.class);
+
+    @Test
+    public void testBTOff() {
+        doReturn(false).when(mockBluetoothUtils).isBluetoothEnabled(contextMock);
+
+        sut.onReceive(contextMock, intentMock);
+
+        verifyNoMoreInteractions(fitbitGattMock);
+        verify(mockBluetoothUtils).isBluetoothEnabled(contextMock);
+        verifyNoMoreInteractions(intentMock);
+    }
+
+    @Test
+    public void testNoAdapter() {
+        doReturn(false).when(mockBluetoothUtils).isBluetoothEnabled(contextMock);
+
+        sut.onReceive(contextMock, intentMock);
+
+        verifyNoMoreInteractions(fitbitGattMock);
+        verifyNoMoreInteractions(intentMock);
+    }
+
+    @Test
+    public void testScanResultError() {
+        doReturn(true).when(mockBluetoothUtils).isBluetoothEnabled(contextMock);
+        doReturn(ScanFailedReason.SCAN_FAILED_APPLICATION_REGISTRATION_FAILED.getCode()).when(intentMock).getIntExtra(BluetoothLeScanner.EXTRA_ERROR_CODE, ScanFailedReason.SCAN_SUCCESS_NO_ERROR.getCode());
+
+        sut.onReceive(contextMock, intentMock);
+
+        verify(fitbitGattMock).isInitialized();
+        verify(mockBluetoothUtils).isBluetoothEnabled(contextMock);
+        verify(intentMock).getAction();
+        verify(intentMock).getIntExtra(BluetoothLeScanner.EXTRA_CALLBACK_TYPE, ScanSettings.CALLBACK_TYPE_FIRST_MATCH);
+        verify(intentMock).getIntExtra(BluetoothLeScanner.EXTRA_ERROR_CODE, ScanFailedReason.SCAN_SUCCESS_NO_ERROR.getCode());
+        verifyNoMoreInteractions(intentMock);
+        verifyNoMoreInteractions(fitbitGattMock);
+    }
+
+
+    @Test
+    public void testEmptyScanResults() {
+        doReturn(true).when(mockBluetoothUtils).isBluetoothEnabled(contextMock);
+        doReturn(ScanFailedReason.SCAN_SUCCESS_NO_ERROR.getCode()).when(intentMock).getIntExtra(BluetoothLeScanner.EXTRA_ERROR_CODE, ScanFailedReason.SCAN_SUCCESS_NO_ERROR.getCode());
+        doReturn(new ArrayList<ScanResult>()).when(intentMock).getParcelableArrayListExtra(BluetoothLeScanner.EXTRA_LIST_SCAN_RESULT);
+
+        sut.onReceive(contextMock, intentMock);
+
+        verify(fitbitGattMock).isInitialized();
+        verify(mockBluetoothUtils).isBluetoothEnabled(contextMock);
+        verify(intentMock).getAction();
+        verify(intentMock).getIntExtra(BluetoothLeScanner.EXTRA_CALLBACK_TYPE, ScanSettings.CALLBACK_TYPE_FIRST_MATCH);
+        verify(intentMock).getIntExtra(BluetoothLeScanner.EXTRA_ERROR_CODE, ScanFailedReason.SCAN_SUCCESS_NO_ERROR.getCode());
+        verify(intentMock).getParcelableArrayListExtra(BluetoothLeScanner.EXTRA_LIST_SCAN_RESULT);
+        verifyNoMoreInteractions(intentMock);
+        verifyNoMoreInteractions(fitbitGattMock);
+    }
+
+    @Test
+    public void testNullResultSet() {
+        doReturn(true).when(mockBluetoothUtils).isBluetoothEnabled(contextMock);
+        doReturn(ScanFailedReason.SCAN_SUCCESS_NO_ERROR.getCode()).when(intentMock).getIntExtra(BluetoothLeScanner.EXTRA_ERROR_CODE, ScanFailedReason.SCAN_SUCCESS_NO_ERROR.getCode());
+        doReturn(null).when(intentMock).getParcelableArrayListExtra(BluetoothLeScanner.EXTRA_LIST_SCAN_RESULT);
+
+        sut.onReceive(contextMock, intentMock);
+
+        verify(fitbitGattMock).isInitialized();
+        verify(mockBluetoothUtils).isBluetoothEnabled(contextMock);
+        verify(intentMock).getAction();
+        verify(intentMock).getIntExtra(BluetoothLeScanner.EXTRA_CALLBACK_TYPE, ScanSettings.CALLBACK_TYPE_FIRST_MATCH);
+        verify(intentMock).getIntExtra(BluetoothLeScanner.EXTRA_ERROR_CODE, ScanFailedReason.SCAN_SUCCESS_NO_ERROR.getCode());
+        verify(intentMock).getParcelableArrayListExtra(BluetoothLeScanner.EXTRA_LIST_SCAN_RESULT);
+        verifyNoMoreInteractions(intentMock);
+        verifyNoMoreInteractions(fitbitGattMock);
+    }
+
+
+    @Test
+    public void testNoClientCB() {
+        ArrayList<ScanResult> results = new ArrayList<>();
+        results.add(mock(ScanResult.class));
+
+        doReturn(true).when(mockBluetoothUtils).isBluetoothEnabled(contextMock);
+        doReturn(ScanFailedReason.SCAN_SUCCESS_NO_ERROR.getCode()).when(intentMock).getIntExtra(BluetoothLeScanner.EXTRA_ERROR_CODE, ScanFailedReason.SCAN_SUCCESS_NO_ERROR.getCode());
+        doReturn(results).when(intentMock).getParcelableArrayListExtra(BluetoothLeScanner.EXTRA_LIST_SCAN_RESULT);
+        doReturn(null).when(fitbitGattMock).getClientCallback();
+
+        sut.onReceive(contextMock, intentMock);
+
+        verify(fitbitGattMock).isInitialized();
+        verify(fitbitGattMock).getClientCallback();
+        verify(mockBluetoothUtils).isBluetoothEnabled(contextMock);
+        verify(intentMock).getAction();
+        verify(intentMock).getIntExtra(BluetoothLeScanner.EXTRA_CALLBACK_TYPE, ScanSettings.CALLBACK_TYPE_FIRST_MATCH);
+        verify(intentMock).getIntExtra(BluetoothLeScanner.EXTRA_ERROR_CODE, ScanFailedReason.SCAN_SUCCESS_NO_ERROR.getCode());
+        verify(intentMock).getParcelableArrayListExtra(BluetoothLeScanner.EXTRA_LIST_SCAN_RESULT);
+        verifyNoMoreInteractions(intentMock);
+        verifyNoMoreInteractions(fitbitGattMock);
+    }
+
+
+    @Test
+    public void testCreateRunnable() {
+        ArrayList<ScanResult> results = new ArrayList<>();
+        ScanResult scanResultMock = mock(ScanResult.class);
+        results.add(scanResultMock);
+        Handler handler = mock(Handler.class);
+        GattClientCallback gattClientCallbackMock = mock(GattClientCallback.class);
+
+
+        doReturn(true).when(mockBluetoothUtils).isBluetoothEnabled(contextMock);
+        doReturn(ScanFailedReason.SCAN_SUCCESS_NO_ERROR.getCode()).when(intentMock).getIntExtra(BluetoothLeScanner.EXTRA_ERROR_CODE, ScanFailedReason.SCAN_SUCCESS_NO_ERROR.getCode());
+        doReturn(results).when(intentMock).getParcelableArrayListExtra(BluetoothLeScanner.EXTRA_LIST_SCAN_RESULT);
+        doReturn(gattClientCallbackMock).when(fitbitGattMock).getClientCallback();
+        doReturn(handler).when(gattClientCallbackMock).getClientCallbackHandler();
+
+        sut.onReceive(contextMock, intentMock);
+
+        verify(fitbitGattMock).isInitialized();
+        verify(fitbitGattMock).getClientCallback();
+        verify(mockBluetoothUtils).isBluetoothEnabled(contextMock);
+        verify(intentMock).getAction();
+        verify(intentMock).getIntExtra(BluetoothLeScanner.EXTRA_CALLBACK_TYPE, ScanSettings.CALLBACK_TYPE_FIRST_MATCH);
+        verify(intentMock).getIntExtra(BluetoothLeScanner.EXTRA_ERROR_CODE, ScanFailedReason.SCAN_SUCCESS_NO_ERROR.getCode());
+        verify(intentMock).getParcelableArrayListExtra(BluetoothLeScanner.EXTRA_LIST_SCAN_RESULT);
+        verify(handler).post(any());
+        verifyNoMoreInteractions(intentMock);
+        verifyNoMoreInteractions(fitbitGattMock);
+    }
+
+    @Test
+    public void testAddDeviceFromPI() {
+        ArrayList<ScanResult> results = new ArrayList<>();
+        ScanResult scanResultMock = mock(ScanResult.class);
+        results.add(scanResultMock);
+        Handler handler = mock(Handler.class);
+        GattClientCallback gattClientCallbackMock = mock(GattClientCallback.class);
+
+
+        BluetoothDevice device = mock(BluetoothDevice.class);
+        doReturn("BI:TG:AT:IO").when(device).getAddress();
+        doReturn(mock(ScanRecord.class)).when(scanResultMock).getScanRecord();
+        doReturn(-60).when(scanResultMock).getRssi();
+        doReturn(device).when(scanResultMock).getDevice();
+        doReturn(true).when(fitbitGattMock).isInitialized();
+        doReturn(true).when(fitbitGattMock).isPendingIntentScanning();
+        doReturn(true).when(mockBluetoothUtils).isBluetoothEnabled(contextMock);
+        doReturn(ScanFailedReason.SCAN_SUCCESS_NO_ERROR.getCode()).when(intentMock).getIntExtra(BluetoothLeScanner.EXTRA_ERROR_CODE, ScanFailedReason.SCAN_SUCCESS_NO_ERROR.getCode());
+        doReturn(results).when(intentMock).getParcelableArrayListExtra(BluetoothLeScanner.EXTRA_LIST_SCAN_RESULT);
+        doReturn(gattClientCallbackMock).when(fitbitGattMock).getClientCallback();
+        doReturn(handler).when(gattClientCallbackMock).getClientCallbackHandler();
+
+        doAnswer(invocation -> {
+            Runnable runnable = invocation.getArgument(0);
+            runnable.run();
+            return true;
+        }).when(handler).post(any());
+
+        sut.onReceive(contextMock, intentMock);
+
+        verify(fitbitGattMock,times(2)).isInitialized();
+        verify(fitbitGattMock).isPendingIntentScanning();
+        verify(fitbitGattMock).addBackgroundScannedDeviceConnection(any(FitbitBluetoothDevice.class));
+        verify(fitbitGattMock).getClientCallback();
+        verify(mockBluetoothUtils).isBluetoothEnabled(contextMock);
+        verify(intentMock).getAction();
+        verify(intentMock).getIntExtra(BluetoothLeScanner.EXTRA_CALLBACK_TYPE, ScanSettings.CALLBACK_TYPE_FIRST_MATCH);
+        verify(intentMock).getIntExtra(BluetoothLeScanner.EXTRA_ERROR_CODE, ScanFailedReason.SCAN_SUCCESS_NO_ERROR.getCode());
+        verify(intentMock).getParcelableArrayListExtra(BluetoothLeScanner.EXTRA_LIST_SCAN_RESULT);
+        verify(handler).post(any());
+        verifyNoMoreInteractions(intentMock);
+        verifyNoMoreInteractions(fitbitGattMock);
+    }
+
+
+    @Test
+    public void testAddDeviceFromWakeUpNOPI() {
+        ArrayList<ScanResult> results = new ArrayList<>();
+        ScanResult scanResultMock = mock(ScanResult.class);
+        results.add(scanResultMock);
+        Handler handlerMock = mock(Handler.class);
+        GattClientCallback gattClientCallbackMock = mock(GattClientCallback.class);
+        PeripheralScanner scannerMock = mock(PeripheralScanner.class);
+
+
+        BluetoothDevice device = mock(BluetoothDevice.class);
+        doReturn("BI:TG:AT:IO").when(device).getAddress();
+        doReturn(mock(ScanRecord.class)).when(scanResultMock).getScanRecord();
+        doReturn(-60).when(scanResultMock).getRssi();
+        doReturn(device).when(scanResultMock).getDevice();
+        doReturn(true).when(fitbitGattMock).isInitialized();
+        doReturn(false).when(fitbitGattMock).isPendingIntentScanning();
+        doReturn(true).when(mockBluetoothUtils).isBluetoothEnabled(contextMock);
+        doReturn(ScanFailedReason.SCAN_SUCCESS_NO_ERROR.getCode()).when(intentMock).getIntExtra(BluetoothLeScanner.EXTRA_ERROR_CODE, ScanFailedReason.SCAN_SUCCESS_NO_ERROR.getCode());
+        doReturn(results).when(intentMock).getParcelableArrayListExtra(BluetoothLeScanner.EXTRA_LIST_SCAN_RESULT);
+        doReturn(gattClientCallbackMock).when(fitbitGattMock).getClientCallback();
+        doReturn(handlerMock).when(gattClientCallbackMock).getClientCallbackHandler();
+        doReturn(scannerMock).when(fitbitGattMock).getPeripheralScanner();
+
+        doAnswer(invocation -> {
+            Runnable runnable = invocation.getArgument(0);
+            runnable.run();
+            return true;
+        }).when(handlerMock).post(any());
+
+        sut.onReceive(contextMock, intentMock);
+
+        verify(fitbitGattMock,times(2)).isInitialized();
+        verify(fitbitGattMock).isPendingIntentScanning();
+        verify(fitbitGattMock).addBackgroundScannedDeviceConnection(any(FitbitBluetoothDevice.class));
+        verify(fitbitGattMock).getClientCallback();
+        verify(fitbitGattMock).getPeripheralScanner();
+        verify(scannerMock).setIsPendingIntentScanning(true);
+        verify(mockBluetoothUtils).isBluetoothEnabled(contextMock);
+        verify(intentMock).getAction();
+        verify(intentMock).getIntExtra(BluetoothLeScanner.EXTRA_CALLBACK_TYPE, ScanSettings.CALLBACK_TYPE_FIRST_MATCH);
+        verify(intentMock).getIntExtra(BluetoothLeScanner.EXTRA_ERROR_CODE, ScanFailedReason.SCAN_SUCCESS_NO_ERROR.getCode());
+        verify(intentMock).getParcelableArrayListExtra(BluetoothLeScanner.EXTRA_LIST_SCAN_RESULT);
+        verify(handlerMock).post(any());
+        verifyNoMoreInteractions(intentMock);
+        verifyNoMoreInteractions(fitbitGattMock);
+    }
+
+
+    @Test
+    public void testAddDeviceFromWakeUpNOScanner() {
+        ArrayList<ScanResult> results = new ArrayList<>();
+        ScanResult scanResultMock = mock(ScanResult.class);
+        results.add(scanResultMock);
+        Handler handlerMock = mock(Handler.class);
+        GattClientCallback gattClientCallbackMock = mock(GattClientCallback.class);
+
+
+        BluetoothDevice device = mock(BluetoothDevice.class);
+        doReturn("BI:TG:AT:IO").when(device).getAddress();
+        doReturn(mock(ScanRecord.class)).when(scanResultMock).getScanRecord();
+        doReturn(-60).when(scanResultMock).getRssi();
+        doReturn(device).when(scanResultMock).getDevice();
+        doReturn(true).when(fitbitGattMock).isInitialized();
+        doReturn(true).when(fitbitGattMock).isInitialized();
+        doReturn(false).when(fitbitGattMock).isPendingIntentScanning();
+        doReturn(true).when(mockBluetoothUtils).isBluetoothEnabled(contextMock);
+        doReturn(ScanFailedReason.SCAN_SUCCESS_NO_ERROR.getCode()).when(intentMock).getIntExtra(BluetoothLeScanner.EXTRA_ERROR_CODE, ScanFailedReason.SCAN_SUCCESS_NO_ERROR.getCode());
+        doReturn(results).when(intentMock).getParcelableArrayListExtra(BluetoothLeScanner.EXTRA_LIST_SCAN_RESULT);
+        doReturn(gattClientCallbackMock).when(fitbitGattMock).getClientCallback();
+        doReturn(handlerMock).when(gattClientCallbackMock).getClientCallbackHandler();
+        doReturn(null).when(fitbitGattMock).getPeripheralScanner();
+
+        doAnswer(invocation -> {
+            Runnable runnable = invocation.getArgument(0);
+            runnable.run();
+            return true;
+        }).when(handlerMock).post(any());
+
+        sut.onReceive(contextMock, intentMock);
+
+        verify(fitbitGattMock,times(2)).isInitialized();
+        verify(fitbitGattMock).isPendingIntentScanning();
+        verify(fitbitGattMock).addBackgroundScannedDeviceConnection(any(FitbitBluetoothDevice.class));
+        verify(fitbitGattMock).getClientCallback();
+        verify(fitbitGattMock).getPeripheralScanner();
+        verify(mockBluetoothUtils).isBluetoothEnabled(contextMock);
+        verify(intentMock).getAction();
+        verify(intentMock).getIntExtra(BluetoothLeScanner.EXTRA_CALLBACK_TYPE, ScanSettings.CALLBACK_TYPE_FIRST_MATCH);
+        verify(intentMock).getIntExtra(BluetoothLeScanner.EXTRA_ERROR_CODE, ScanFailedReason.SCAN_SUCCESS_NO_ERROR.getCode());
+        verify(intentMock).getParcelableArrayListExtra(BluetoothLeScanner.EXTRA_LIST_SCAN_RESULT);
+        verify(handlerMock).post(any());
+        verifyNoMoreInteractions(intentMock);
+        verifyNoMoreInteractions(fitbitGattMock);
+    }
+
+    @Test
+    public void testAddDeviceFromWakeUpFitbitGattNotInitialized() {
+        ArrayList<ScanResult> results = new ArrayList<>();
+        ScanResult scanResultMock = mock(ScanResult.class);
+        results.add(scanResultMock);
+        Handler handlerMock = mock(Handler.class);
+        GattClientCallback gattClientCallbackMock = mock(GattClientCallback.class);
+
+
+        BluetoothDevice device = mock(BluetoothDevice.class);
+        doReturn("BI:TG:AT:IO").when(device).getAddress();
+        doReturn(mock(ScanRecord.class)).when(scanResultMock).getScanRecord();
+        doReturn(-60).when(scanResultMock).getRssi();
+        doReturn(device).when(scanResultMock).getDevice();
+        doReturn(false).when(fitbitGattMock).isInitialized();
+        doReturn(false).when(fitbitGattMock).isPendingIntentScanning();
+        doReturn(true).when(mockBluetoothUtils).isBluetoothEnabled(contextMock);
+        doReturn(ScanFailedReason.SCAN_SUCCESS_NO_ERROR.getCode()).when(intentMock).getIntExtra(BluetoothLeScanner.EXTRA_ERROR_CODE, ScanFailedReason.SCAN_SUCCESS_NO_ERROR.getCode());
+        doReturn(results).when(intentMock).getParcelableArrayListExtra(BluetoothLeScanner.EXTRA_LIST_SCAN_RESULT);
+        doReturn(gattClientCallbackMock).when(fitbitGattMock).getClientCallback();
+        doReturn(handlerMock).when(gattClientCallbackMock).getClientCallbackHandler();
+        doReturn(null).when(fitbitGattMock).getPeripheralScanner();
+
+        doAnswer(invocation -> {
+            Runnable runnable = invocation.getArgument(0);
+            runnable.run();
+            return true;
+        }).when(handlerMock).post(any());
+
+        AtomicReference<FitbitGatt.FitbitGattCallback> gattCallbackRef = new AtomicReference<>();
+        doAnswer(invocation -> {
+            gattCallbackRef.set(invocation.getArgument(0));
+            gattCallbackRef.get().onGattClientStarted();
+            return true;
+        }).when(fitbitGattMock).registerGattEventListener(any());
+
+        sut.onReceive(contextMock, intentMock);
+
+        verify(fitbitGattMock,times(2)).isInitialized();
+        verify(fitbitGattMock).isPendingIntentScanning();
+        verify(fitbitGattMock).addBackgroundScannedDeviceConnection(any(FitbitBluetoothDevice.class));
+        verify(fitbitGattMock).getClientCallback();
+        verify(fitbitGattMock).registerGattEventListener(any());
+        verify(fitbitGattMock).getPeripheralScanner();
+        verify(fitbitGattMock).unregisterGattEventListener(gattCallbackRef.get());
+        verify(mockBluetoothUtils).isBluetoothEnabled(contextMock);
+        verify(intentMock).getAction();
+        verify(intentMock).getIntExtra(BluetoothLeScanner.EXTRA_CALLBACK_TYPE, ScanSettings.CALLBACK_TYPE_FIRST_MATCH);
+        verify(intentMock).getIntExtra(BluetoothLeScanner.EXTRA_ERROR_CODE, ScanFailedReason.SCAN_SUCCESS_NO_ERROR.getCode());
+        verify(intentMock).getParcelableArrayListExtra(BluetoothLeScanner.EXTRA_LIST_SCAN_RESULT);
+        verify(handlerMock).post(any());
+        verifyNoMoreInteractions(intentMock);
+        verifyNoMoreInteractions(fitbitGattMock);
+    }
+}

--- a/src/test/java/com/fitbit/bluetooth/fbgatt/PeripheralScannerTest.java
+++ b/src/test/java/com/fitbit/bluetooth/fbgatt/PeripheralScannerTest.java
@@ -8,7 +8,7 @@
 
 package com.fitbit.bluetooth.fbgatt;
 
-import com.fitbit.bluetooth.fbgatt.util.GattUtils;
+import com.fitbit.bluetooth.fbgatt.util.BluetoothUtils;
 import com.fitbit.bluetooth.fbgatt.util.LooperWatchdog;
 
 import android.bluetooth.BluetoothAdapter;
@@ -74,7 +74,7 @@ public class PeripheralScannerTest {
     @Before
     public void before(){
         mockScanner = MockLollipopScanner.BluetoothAdapter.getBluetoothLeScanner();
-        GattUtils utilsMock = mock(GattUtils.class);
+        BluetoothUtils utilsMock = mock(BluetoothUtils.class);
         LowEnergyAclListener lowEnergyAclListenerMock = mock(LowEnergyAclListener.class);
         BluetoothAdapter adapterMock = mock(BluetoothAdapter.class);
         BluetoothRadioStatusListener bluetoothRadioStatusListenerMock = mock(BluetoothRadioStatusListener.class);
@@ -95,11 +95,10 @@ public class PeripheralScannerTest {
         when(mockHandler.getLooper()).thenReturn(mockMainThreadLooper);
         doReturn(mockContext).when(mockContext).getApplicationContext();
         doReturn(bluetoothRadioStatusListenerMock).when(dependencyProviderMock).getNewBluetoothRadioStatusListener(mockContext, false);
-        doReturn(utilsMock).when(dependencyProviderMock).getNewGattUtils();
+        doReturn(utilsMock).when(dependencyProviderMock).getBluetoothUtils();
         doReturn(lowEnergyAclListenerMock).when(dependencyProviderMock).getNewLowEnergyAclListener();
-        doReturn(adapterMock).when(utilsMock).getBluetoothAdapter(mockContext);
         doCallRealMethod().when(dependencyProviderMock).getNewPeripheralScanner(eq(mockContext), any());
-        doReturn(true).when(adapterMock).isEnabled();
+        doReturn(true).when(utilsMock).isBluetoothEnabled(mockContext);
         gatt = FitbitGatt.getInstance();
         gatt.setDependencyProvider(dependencyProviderMock);
         gatt.setAsyncOperationThreadWatchdog(mock(LooperWatchdog.class));

--- a/src/test/java/com/fitbit/bluetooth/fbgatt/ScannedDevicesInvalidationTests.java
+++ b/src/test/java/com/fitbit/bluetooth/fbgatt/ScannedDevicesInvalidationTests.java
@@ -9,7 +9,7 @@
 package com.fitbit.bluetooth.fbgatt;
 
 import com.fitbit.bluetooth.fbgatt.tx.mocks.ReadGattCharacteristicMockTransaction;
-import com.fitbit.bluetooth.fbgatt.util.GattUtils;
+import com.fitbit.bluetooth.fbgatt.util.BluetoothUtils;
 import com.fitbit.bluetooth.fbgatt.util.LooperWatchdog;
 
 import android.bluetooth.BluetoothAdapter;
@@ -57,7 +57,7 @@ public class ScannedDevicesInvalidationTests {
 
     @Before
     public void before() {
-        GattUtils utilsMock = mock(GattUtils.class);
+        BluetoothUtils utilsMock = mock(BluetoothUtils.class);
         LowEnergyAclListener lowEnergyAclListenerMock = mock(LowEnergyAclListener.class);
         BluetoothAdapter adapterMock = mock(BluetoothAdapter.class);
         BluetoothRadioStatusListener bluetoothRadioStatusListenerMock = mock(BluetoothRadioStatusListener.class);
@@ -65,7 +65,7 @@ public class ScannedDevicesInvalidationTests {
         Context mockContext = mock(Context.class);
         doReturn(mockContext).when(mockContext).getApplicationContext();
         doReturn(bluetoothRadioStatusListenerMock).when(dependencyProviderMock).getNewBluetoothRadioStatusListener(mockContext, false);
-        doReturn(utilsMock).when(dependencyProviderMock).getNewGattUtils();
+        doReturn(utilsMock).when(dependencyProviderMock).getBluetoothUtils();
         doReturn(lowEnergyAclListenerMock).when(dependencyProviderMock).getNewLowEnergyAclListener();
         doReturn(adapterMock).when(utilsMock).getBluetoothAdapter(mockContext);
         doCallRealMethod().when(dependencyProviderMock).getNewPeripheralScanner(eq(mockContext), any());

--- a/src/test/java/com/fitbit/bluetooth/fbgatt/TestUtils.java
+++ b/src/test/java/com/fitbit/bluetooth/fbgatt/TestUtils.java
@@ -1,0 +1,25 @@
+/*
+ *  Copyright 2020 Fitbit, Inc. All rights reserved.
+ *
+ *  This Source Code Form is subject to the terms of the Mozilla Public
+ *  License, v. 2.0. If a copy of the MPL was not distributed with this
+ *  file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+package com.fitbit.bluetooth.fbgatt;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+
+class TestUtils {
+
+    void setStaticField(Field field, int value) throws NoSuchFieldException, IllegalAccessException {
+        field.setAccessible(true);
+
+        Field modifiersField = Field.class.getDeclaredField("modifiers");
+        modifiersField.setAccessible(true);
+        modifiersField.setInt(field, field.getModifiers() & ~Modifier.FINAL);
+
+        field.set(null, value);
+    }
+}

--- a/src/test/java/com/fitbit/bluetooth/fbgatt/util/BluetoothUtilsTest.java
+++ b/src/test/java/com/fitbit/bluetooth/fbgatt/util/BluetoothUtilsTest.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright 2019 Fitbit, Inc. All rights reserved.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+package com.fitbit.bluetooth.fbgatt.util;
+
+import android.bluetooth.BluetoothAdapter;
+import android.bluetooth.BluetoothManager;
+import android.bluetooth.le.BluetoothLeScanner;
+import android.content.Context;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class BluetoothUtilsTest {
+
+    private Context mockContext = mock(Context.class);
+    private BluetoothManager mockBluetoothManager = mock(BluetoothManager.class);
+    private BluetoothAdapter mockBluetoothAdapter = mock(BluetoothAdapter.class);
+    private BluetoothManagerProvider mockBluetoothManagerProvider = mock(BluetoothManagerProvider.class);
+
+    private BluetoothUtils utils = new BluetoothUtils(mockBluetoothManagerProvider);
+
+    @Test
+    public void getBluetoothAdapter_shouldReturnNullIfBluetoothNotSupported() {
+        mockBluetoothNotAvailable();
+
+        BluetoothAdapter adapter = utils.getBluetoothAdapter(mockContext);
+        assertNull(adapter);
+    }
+
+    @Test
+    public void getBluetoothAdapter_shouldReturnNullIfNoDefaultAdapter() {
+        mockBluetoothAvailable();
+        mockNoDefaultAdapter();
+
+        BluetoothAdapter adapter = utils.getBluetoothAdapter(mockContext);
+        assertNull(adapter);
+    }
+
+    @Test
+    public void getBluetoothAdapter_shouldReturnAdapterIfBluetoothIsSupported() {
+        mockBluetoothAvailable();
+        mockAdapter();
+
+        BluetoothAdapter adapter = utils.getBluetoothAdapter(mockContext);
+        assertEquals(mockBluetoothAdapter, adapter);
+    }
+
+    @Test
+    public void getBluetoothLeScanner_shouldReturnNullIfBluetoothNotSupported() {
+        mockBluetoothNotAvailable();
+
+        BluetoothLeScanner scanner = utils.getBluetoothLeScanner(mockContext);
+        assertNull(scanner);
+    }
+
+    @Test
+    public void getBluetoothLeScanner_shouldReturnNullIfNoDefaultAdapter() {
+        mockBluetoothAvailable();
+        mockNoDefaultAdapter();
+
+        BluetoothLeScanner scanner = utils.getBluetoothLeScanner(mockContext);
+        assertNull(scanner);
+    }
+
+    @Test
+    public void getBluetoothLeScanner_shouldReturnNullIfBluetoothNotEnabled() {
+        mockBluetoothAvailable();
+        mockAdapter();
+        mockBleDisabled();
+
+        BluetoothLeScanner scanner = utils.getBluetoothLeScanner(mockContext);
+        assertNull(scanner);
+    }
+
+    @Test
+    public void getBluetoothLeScanner_shouldReturnAdapterIfBluetoothIsSupported() {
+        mockBluetoothAvailable();
+        mockAdapter();
+        mockBleEnabled();
+        BluetoothLeScanner mockBluetoothLeScanner = mock(BluetoothLeScanner.class);
+        when(mockBluetoothAdapter.getBluetoothLeScanner()).thenReturn(mockBluetoothLeScanner);
+
+        BluetoothLeScanner scanner = utils.getBluetoothLeScanner(mockContext);
+        assertEquals(mockBluetoothLeScanner, scanner);
+    }
+
+    @Test
+    public void isBluetoothEnabled_shouldReturnFalseIfBluetoothNotSupported() {
+        mockBluetoothNotAvailable();
+
+        boolean enabled = utils.isBluetoothEnabled(mockContext);
+        assertFalse(enabled);
+    }
+
+    @Test
+    public void isBluetoothEnabled_shouldReturnFalseIfNoDefaultAdapter() {
+        mockBluetoothAvailable();
+        mockNoDefaultAdapter();
+
+        boolean enabled = utils.isBluetoothEnabled(mockContext);
+        assertFalse(enabled);
+    }
+
+    @Test
+    public void isBluetoothEnabled_shouldReturnTrueIfEnabled() {
+        mockBluetoothAvailable();
+        mockAdapter();
+        mockBleEnabled();
+
+        boolean enabled = utils.isBluetoothEnabled(mockContext);
+        assertTrue(enabled);
+    }
+
+    private void mockBluetoothNotAvailable() {
+        when(mockBluetoothManagerProvider.get(mockContext)).thenReturn(null);
+    }
+
+    private void mockBluetoothAvailable() {
+        when(mockBluetoothManagerProvider.get(mockContext)).thenReturn(mockBluetoothManager);
+    }
+
+    private void mockNoDefaultAdapter() {
+        when(mockBluetoothManager.getAdapter()).thenReturn(null);
+    }
+
+    private void mockAdapter() {
+        when(mockBluetoothManager.getAdapter()).thenReturn(mockBluetoothAdapter);
+    }
+
+    private void mockBleEnabled() {
+        when(mockBluetoothAdapter.isEnabled()).thenReturn(true);
+    }
+
+    private void mockBleDisabled() {
+        when(mockBluetoothAdapter.isEnabled()).thenReturn(false);
+    }
+}


### PR DESCRIPTION
fixes
Fix Stale Bluetooth enabled status and unit test updates

description
Fix issue were Ble enabled state is stored during class creation and reused when performing the operation, this could result in stale Ble enabled state when the operations are actually executed

testing
added/updated unit tests