### PR TITLE
 Update new server connection reference when opening a new server

### DIFF
--- a/src/main/java/com/fitbit/bluetooth/fbgatt/FitbitGatt.java
+++ b/src/main/java/com/fitbit/bluetooth/fbgatt/FitbitGatt.java
@@ -1439,7 +1439,7 @@ public class FitbitGatt implements PeripheralScanner.TrackerScannerListener, Blu
              * application's data in the application list with system apps shown.  The gatt
              * cache is probably corrupt
              */
-            fitbitGattAsyncOperationHandler.post(tryAndStartGattServer(this.appContext, callback, manager));
+            fitbitGattAsyncOperationHandler.post(tryAndStartGattServer(this.appContext, callback, manager, null));
         } else {
             Timber.w("No bluetooth manager, we must be simulating, or BT is off!!!");
             callback.onGattServerStatus(false);
@@ -1448,7 +1448,7 @@ public class FitbitGatt implements PeripheralScanner.TrackerScannerListener, Blu
 
     @NonNull
     @VisibleForTesting
-    Runnable tryAndStartGattServer(Context context, OpenGattServerCallback callback, BluetoothManager manager) {
+    Runnable tryAndStartGattServer(Context context, OpenGattServerCallback callback, BluetoothManager manager, GattServerConnection newGattServerConnection) {
         return () -> {
             synchronized (FitbitGatt.this) {
                 //may have been started already in another thread in parallel trough another post
@@ -1462,6 +1462,8 @@ public class FitbitGatt implements PeripheralScanner.TrackerScannerListener, Blu
                     gattServer = manager.openGattServer(context, serverCallback);
                     if (gattServer != null) {
                         if (serverConnection != null) {
+                            // We have a new server instance we need to replace it in the GattServerConnection
+                            replaceServerConnection(context, newGattServerConnection);
                             // let's try to run a clear tx since we already have a server connection
                             ClearServerServicesTransaction clearServices = new ClearServerServicesTransaction(serverConnection,
                                     GattState.CLEAR_GATT_SERVER_SERVICES_SUCCESS);
@@ -1485,12 +1487,23 @@ public class FitbitGatt implements PeripheralScanner.TrackerScannerListener, Blu
         };
     }
 
+    private void replaceServerConnection(Context context, GattServerConnection newGattServerConnection) {
+        if (serverConnection != null) {
+            serverConnection.close();
+        }
+        if (newGattServerConnection != null) {
+            setGattServerConnection(newGattServerConnection);
+        } else {
+            setGattServerConnection(new GattServerConnection(gattServer, context.getMainLooper()));
+        }
+        serverConnection.setState(GattState.IDLE);
+    }
+
     @NonNull
     private GattTransactionCallback getGattClearServicesTransactionCallback(Context context, OpenGattServerCallback callback) {
         return result -> {
             // whether this succeeds or not, we want to proceed
             Timber.v("The gatt server services were cleared %s", result.resultStatus);
-            setGattServerConnection(new GattServerConnection(gattServer, context.getMainLooper()));
             serverConnection.setState(GattState.IDLE);
             callback.onGattServerStatus(true);
             isGattServerStarting.set(false);

--- a/src/test/java/com/fitbit/bluetooth/fbgatt/FitbitGattTest.java
+++ b/src/test/java/com/fitbit/bluetooth/fbgatt/FitbitGattTest.java
@@ -47,6 +47,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.when;
 
 /**
  * Responsible for testing the {@link FitbitGatt} api
@@ -237,6 +238,7 @@ public class FitbitGattTest {
         FitbitGatt.FitbitGattCallback cb = mock(FitbitGatt.FitbitGattCallback.class);
         GattServerConnection prevConnection = mock(GattServerConnection.class);
         GattServerConnection newConnection = mock(GattServerConnection.class);
+        when(newConnection.getGattState()).thenReturn(GattState.IDLE);
         doAnswer(invocation -> {
             TransactionResult tr = new TransactionResult.Builder()
                 .resultStatus(TransactionResult.TransactionResultStatus.SUCCESS).build();


### PR DESCRIPTION
Creates/Updates the GattServerConnection with the correct reference to the new server.
