### PR TITLE
Remove enum ambiguity from TransactionResult.responseStatus()

### DIFF
--- a/src/main/java/com/fitbit/bluetooth/fbgatt/GattClientCallback.java
+++ b/src/main/java/com/fitbit/bluetooth/fbgatt/GattClientCallback.java
@@ -13,9 +13,9 @@ import com.fitbit.bluetooth.fbgatt.btcopies.BluetoothGattDescriptorCopy;
 import com.fitbit.bluetooth.fbgatt.tx.GattClientDiscoverServicesTransaction;
 import com.fitbit.bluetooth.fbgatt.tx.RequestGattClientPhyChangeTransaction;
 import com.fitbit.bluetooth.fbgatt.tx.RequestMtuGattTransaction;
+import com.fitbit.bluetooth.fbgatt.util.GattDisconnectReason;
 import com.fitbit.bluetooth.fbgatt.util.GattStatus;
 import com.fitbit.bluetooth.fbgatt.util.GattUtils;
-
 import android.bluetooth.BluetoothDevice;
 import android.bluetooth.BluetoothGatt;
 import android.bluetooth.BluetoothGattCallback;
@@ -25,13 +25,11 @@ import android.bluetooth.BluetoothGattService;
 import android.bluetooth.BluetoothProfile;
 import android.os.Handler;
 import android.os.Looper;
-
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
-
 import timber.log.Timber;
 
 /**
@@ -123,7 +121,7 @@ public class GattClientCallback extends BluetoothGattCallback {
                         .txPhy(txPhy)
                         .rxPhy(rxPhy)
                         .gattState(conn.getGattState())
-                        .responseStatus(GattDisconnectReason.getReasonForCode(status).ordinal()).build(), conn);
+                        .responseStatus(GattStatus.getStatusForCode(status)).build(), conn);
                 }
             });
         }
@@ -224,7 +222,7 @@ public class GattClientCallback extends BluetoothGattCallback {
                             asyncConnListener.onClientConnectionStateChanged(new TransactionResult.Builder()
                                     .resultStatus(TransactionResult.TransactionResultStatus.FAILURE)
                                     .gattState(conn.getGattState())
-                                    .responseStatus(GattDisconnectReason.getReasonForCode(status).ordinal()).build(), conn);
+                                    .disconnectReason(GattDisconnectReason.getReasonForCode(status)).build(), conn);
                         }
                     }, HOT_QUEUE_EMPTYING_TIME);
                 } else {
@@ -256,8 +254,7 @@ public class GattClientCallback extends BluetoothGattCallback {
                     for(ConnectionEventListener asyncConnListener : conn.getConnectionEventListeners()) {
                         handler.post(() -> asyncConnListener.onClientConnectionStateChanged(new TransactionResult.Builder()
                             .resultStatus(TransactionResult.TransactionResultStatus.SUCCESS)
-                            .gattState(conn.getGattState())
-                            .responseStatus(GattDisconnectReason.getReasonForCode(status).ordinal()).build(), conn));
+                            .gattState(conn.getGattState()).build(), conn));
                     }
                 });
                 break;
@@ -298,7 +295,7 @@ public class GattClientCallback extends BluetoothGattCallback {
                         .transactionName(GattClientDiscoverServicesTransaction.NAME)
                         .serverServices(discoveredServices)
                         .gattState(conn.getGattState())
-                        .responseStatus(GattDisconnectReason.getReasonForCode(status).ordinal()).build(), conn);
+                        .responseStatus(GattStatus.getStatusForCode(status)).build(), conn);
                 }
             });
         }
@@ -473,7 +470,7 @@ public class GattClientCallback extends BluetoothGattCallback {
                     .transactionName(RequestMtuGattTransaction.NAME)
                     .mtu(mtu)
                     .gattState(conn.getGattState())
-                    .responseStatus(GattDisconnectReason.getReasonForCode(status).ordinal()).build();
+                    .responseStatus(GattStatus.getStatusForCode(status)).build();
             // since this is one of the events that could happen asynchronously, we will
             // need to iterate through our connection listeners
             handler.post(() -> {

--- a/src/main/java/com/fitbit/bluetooth/fbgatt/GattConnection.java
+++ b/src/main/java/com/fitbit/bluetooth/fbgatt/GattConnection.java
@@ -294,7 +294,7 @@ public class GattConnection implements Closeable {
                 asyncConnListener.onClientConnectionStateChanged(new TransactionResult.Builder()
                         .resultStatus(TransactionResult.TransactionResultStatus.FAILURE)
                         .gattState(getGattState())
-                        .responseStatus(GattStatus.GATT_UNKNOWN.ordinal()).build(), this);
+                        .responseStatus(GattStatus.GATT_UNKNOWN).build(), this);
             }
         } else {
             throw new IllegalStateException(String.format(Locale.ENGLISH, "[%s] You can't simulate a disconnection if you are not in mock mode", getDevice()));

--- a/src/main/java/com/fitbit/bluetooth/fbgatt/GattDisconnectReason.java
+++ b/src/main/java/com/fitbit/bluetooth/fbgatt/GattDisconnectReason.java
@@ -15,6 +15,7 @@ package com.fitbit.bluetooth.fbgatt;
  * Created by iowens on 8/10/17.
  */
 
+@Deprecated
 enum GattDisconnectReason {
     GATT_CONN_UNKNOWN(0),
     GATT_CONN_NO_RESOURCES(4),              /* connection fail for l2cap resource failure */

--- a/src/main/java/com/fitbit/bluetooth/fbgatt/GattServerCallback.java
+++ b/src/main/java/com/fitbit/bluetooth/fbgatt/GattServerCallback.java
@@ -10,9 +10,9 @@ package com.fitbit.bluetooth.fbgatt;
 
 import com.fitbit.bluetooth.fbgatt.btcopies.BluetoothGattCharacteristicCopy;
 import com.fitbit.bluetooth.fbgatt.btcopies.BluetoothGattDescriptorCopy;
+import com.fitbit.bluetooth.fbgatt.util.GattDisconnectReason;
 import com.fitbit.bluetooth.fbgatt.util.GattStatus;
 import com.fitbit.bluetooth.fbgatt.util.GattUtils;
-
 import android.bluetooth.BluetoothDevice;
 import android.bluetooth.BluetoothGattCharacteristic;
 import android.bluetooth.BluetoothGattDescriptor;
@@ -23,13 +23,11 @@ import android.bluetooth.BluetoothProfile;
 import android.os.Build;
 import android.os.Handler;
 import android.os.Looper;
-
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.UUID;
-
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.VisibleForTesting;
@@ -112,7 +110,7 @@ class GattServerCallback extends BluetoothGattServerCallback {
                         // success because we received this data
                         TransactionResult result = new TransactionResult.Builder()
                                 .gattState(conn.getGattState())
-                                .responseStatus(status)
+                                .disconnectReason(GattDisconnectReason.getReasonForCode(status))
                                 .resultStatus(TransactionResult.TransactionResultStatus.FAILURE).build();
                         handler.post(() -> asyncListener.onServerConnectionStateChanged(device, result, conn));
                     }
@@ -127,7 +125,6 @@ class GattServerCallback extends BluetoothGattServerCallback {
                         // success because we received this data
                         TransactionResult result = new TransactionResult.Builder()
                                 .gattState(conn.getGattState())
-                                .responseStatus(status)
                                 .resultStatus(TransactionResult.TransactionResultStatus.SUCCESS).build();
                         handler.post(() -> asyncListener.onServerConnectionStateChanged(device, result, conn));
                     }
@@ -395,7 +392,7 @@ class GattServerCallback extends BluetoothGattServerCallback {
         ArrayList<GattServerListener> copy = new ArrayList<>(listeners.size());
         copy.addAll(listeners);
         for (GattServerListener listener : copy) {
-            handler.post(() -> listener.onServerNotificationSent(device, GattStatus.getStatusForCode(status).ordinal()));
+            handler.post(() -> listener.onServerNotificationSent(device, GattStatus.getStatusForCode(status)));
         }
     }
 

--- a/src/main/java/com/fitbit/bluetooth/fbgatt/GattServerListener.java
+++ b/src/main/java/com/fitbit/bluetooth/fbgatt/GattServerListener.java
@@ -10,6 +10,7 @@ package com.fitbit.bluetooth.fbgatt;
 
 import com.fitbit.bluetooth.fbgatt.btcopies.BluetoothGattCharacteristicCopy;
 import com.fitbit.bluetooth.fbgatt.btcopies.BluetoothGattDescriptorCopy;
+import com.fitbit.bluetooth.fbgatt.util.GattStatus;
 
 import android.bluetooth.BluetoothDevice;
 import android.bluetooth.BluetoothGattCharacteristic;
@@ -117,7 +118,7 @@ interface GattServerListener {
      * @param device The bluetooth device
      * @param status The status
      */
-    void onServerNotificationSent(BluetoothDevice device, int status);
+    void onServerNotificationSent(BluetoothDevice device, GattStatus status);
 
     /**
      * *DO NOT USE UNLESS YOU KNOW WHAT YOU ARE DOING!!!* library internal method for notifying the {@link FitbitGatt} that the server

--- a/src/main/java/com/fitbit/bluetooth/fbgatt/GattServerTransaction.java
+++ b/src/main/java/com/fitbit/bluetooth/fbgatt/GattServerTransaction.java
@@ -10,6 +10,7 @@ package com.fitbit.bluetooth.fbgatt;
 
 import com.fitbit.bluetooth.fbgatt.btcopies.BluetoothGattCharacteristicCopy;
 import com.fitbit.bluetooth.fbgatt.btcopies.BluetoothGattDescriptorCopy;
+import com.fitbit.bluetooth.fbgatt.util.GattStatus;
 import com.fitbit.bluetooth.fbgatt.util.GattUtils;
 import android.bluetooth.BluetoothDevice;
 import android.bluetooth.BluetoothGattService;
@@ -162,7 +163,7 @@ public class GattServerTransaction extends GattTransaction<GattServerTransaction
     }
 
     @Override
-    public void onServerNotificationSent(BluetoothDevice device, int status) {
+    public void onServerNotificationSent(BluetoothDevice device, GattStatus status) {
         Timber.v("[%s] onServerNotificationSent not handled in tx: %s", utils.debugSafeGetBtDeviceName(device), getName());
     }
 

--- a/src/main/java/com/fitbit/bluetooth/fbgatt/tx/AddGattServerServiceCharacteristicDescriptorTransaction.java
+++ b/src/main/java/com/fitbit/bluetooth/fbgatt/tx/AddGattServerServiceCharacteristicDescriptorTransaction.java
@@ -65,7 +65,7 @@ public class AddGattServerServiceCharacteristicDescriptorTransaction extends Gat
                 if(null != serviceChar) {
                     if(doesDescriptorAlreadyExist(serviceChar, descriptor)) {
                         TransactionResult.Builder builder = new TransactionResult.Builder().transactionName(getName());
-                        builder.responseStatus(GattDisconnectReason.getReasonForCode(GattDisconnectReason.GATT_CONN_NO_RESOURCES.getCode()).ordinal());
+                        builder.disconnectReason(GattDisconnectReason.GATT_CONN_NO_RESOURCES);
                         getGattServer().setState(GattState.ADD_SERVICE_CHARACTERISTIC_DESCRIPTOR_FAILURE);
                         Timber.w("The gatt service characteristic descriptor %s, is a duplicate, and could not be added to characteristic: %s, on service: %s",
                                 serviceChar.getUuid(), descriptor.getUuid(), service.getUuid());
@@ -83,7 +83,7 @@ public class AddGattServerServiceCharacteristicDescriptorTransaction extends Gat
                         builder.serviceUuid(serverService.getUuid())
                                 .characteristicUuid(characteristic.getUuid())
                                 .descriptorUuid(descriptor.getUuid());
-                        builder.responseStatus(GattStatus.GATT_SUCCESS.getCode());
+                        builder.responseStatus(GattStatus.GATT_SUCCESS);
                         getGattServer().setState(GattState.ADD_SERVICE_CHARACTERISTIC_DESCRIPTOR_SUCCESS);
                         Timber.e("The gatt service characteristic descriptor could not be added: %s", service.getUuid());
                         builder.gattState(getGattServer().getGattState())
@@ -105,7 +105,7 @@ public class AddGattServerServiceCharacteristicDescriptorTransaction extends Gat
     private void respondWithError(String message, GattTransactionCallback callback) {
         TransactionResult.Builder builder = new TransactionResult.Builder().transactionName(getName());
         Timber.w(message);
-        builder.responseStatus(GattDisconnectReason.getReasonForCode(GattDisconnectReason.GATT_CONN_NO_RESOURCES.getCode()).ordinal());
+        builder.disconnectReason(GattDisconnectReason.GATT_CONN_NO_RESOURCES);
         getGattServer().setState(GattState.ADD_SERVICE_CHARACTERISTIC_DESCRIPTOR_FAILURE);
         Timber.e("The gatt service characteristic descriptor could not be added: %s", service.getUuid());
         builder.gattState(getGattServer().getGattState())

--- a/src/main/java/com/fitbit/bluetooth/fbgatt/tx/AddGattServerServiceCharacteristicTransaction.java
+++ b/src/main/java/com/fitbit/bluetooth/fbgatt/tx/AddGattServerServiceCharacteristicTransaction.java
@@ -65,7 +65,7 @@ public class AddGattServerServiceCharacteristicTransaction extends GattServerTra
             if(null != getGattServer().getServer().getService(service.getUuid())){
                 if(doesCharacteristicAlreadyExistOnService(service, characteristic)) {
                     TransactionResult.Builder builder = new TransactionResult.Builder().transactionName(getName());
-                    builder.responseStatus(GattDisconnectReason.getReasonForCode(GattDisconnectReason.GATT_CONN_NO_RESOURCES.getCode()).ordinal());
+                    builder.disconnectReason(GattDisconnectReason.GATT_CONN_NO_RESOURCES);
                     getGattServer().setState(GattState.ADD_SERVICE_CHARACTERISTIC_FAILURE);
                     Timber.w("The gatt service characteristic %s, is a duplicate, and could not be added to service: %s",
                             characteristic.getUuid(), service.getUuid());
@@ -80,7 +80,7 @@ public class AddGattServerServiceCharacteristicTransaction extends GattServerTra
                 addCriticalDescriptorsIfNecessary(characteristic);
                 if(service.addCharacteristic(characteristic)) {
                     TransactionResult.Builder builder = new TransactionResult.Builder().transactionName(getName());
-                    builder.responseStatus(GattStatus.GATT_SUCCESS.getCode());
+                    builder.responseStatus(GattStatus.GATT_SUCCESS);
                     getGattServer().setState(GattState.ADD_SERVICE_CHARACTERISTIC_SUCCESS);
                     Timber.e("The gatt service characteristic could not be added: %s", service.getUuid());
                     builder.gattState(getGattServer().getGattState())
@@ -122,7 +122,7 @@ public class AddGattServerServiceCharacteristicTransaction extends GattServerTra
     private void respondWithError(String message, GattTransactionCallback callback) {
         TransactionResult.Builder builder = new TransactionResult.Builder().transactionName(getName());
         Timber.w(message);
-        builder.responseStatus(GattDisconnectReason.getReasonForCode(GattDisconnectReason.GATT_CONN_NO_RESOURCES.getCode()).ordinal());
+        builder.disconnectReason(GattDisconnectReason.GATT_CONN_NO_RESOURCES);
         getGattServer().setState(GattState.ADD_SERVICE_CHARACTERISTIC_DESCRIPTOR_FAILURE);
         Timber.e("The gatt service characteristic could not be added: %s", service.getUuid());
         builder.gattState(getGattServer().getGattState())

--- a/src/main/java/com/fitbit/bluetooth/fbgatt/tx/AddGattServerServiceTransaction.java
+++ b/src/main/java/com/fitbit/bluetooth/fbgatt/tx/AddGattServerServiceTransaction.java
@@ -15,6 +15,7 @@ import com.fitbit.bluetooth.fbgatt.GattState;
 import com.fitbit.bluetooth.fbgatt.GattTransactionCallback;
 import com.fitbit.bluetooth.fbgatt.TransactionResult;
 import com.fitbit.bluetooth.fbgatt.util.GattDisconnectReason;
+import com.fitbit.bluetooth.fbgatt.util.GattStatus;
 
 import android.bluetooth.BluetoothGatt;
 import android.bluetooth.BluetoothGattService;
@@ -55,7 +56,7 @@ public class AddGattServerServiceTransaction extends GattServerTransaction {
             mainThreadHandler.post(() -> {
                 TransactionResult.Builder builder = new TransactionResult.Builder().transactionName(getName());
                 Timber.w("The GATT Server was not started yet, did you start the gatt?");
-                builder.responseStatus(GattDisconnectReason.getReasonForCode(GattDisconnectReason.GATT_CONN_NO_RESOURCES.getCode()).ordinal());
+                builder.disconnectReason(GattDisconnectReason.GATT_CONN_NO_RESOURCES);
                 getGattServer().setState(GattState.ADD_SERVICE_FAILURE);
                 Timber.e("The gatt service could not be added: %s", service.getUuid());
                 builder.gattState(getGattServer().getGattState())
@@ -66,7 +67,7 @@ public class AddGattServerServiceTransaction extends GattServerTransaction {
         } else {
             if(doesGattServerServiceAlreadyExist(service)) {
                 TransactionResult.Builder builder = new TransactionResult.Builder().transactionName(getName());
-                builder.responseStatus(GattDisconnectReason.getReasonForCode(GattDisconnectReason.GATT_CONN_NO_RESOURCES.getCode()).ordinal());
+                builder.disconnectReason(GattDisconnectReason.GATT_CONN_NO_RESOURCES);
                 getGattServer().setState(GattState.ADD_SERVICE_FAILURE);
                 Timber.w("The gatt service %s, is a duplicate, and could not be added to server", service.getUuid());
                 builder.gattState(getGattServer().getGattState())
@@ -87,7 +88,7 @@ public class AddGattServerServiceTransaction extends GattServerTransaction {
             }
             if(!success) {
                 TransactionResult.Builder builder = new TransactionResult.Builder().transactionName(getName());
-                builder.responseStatus(GattDisconnectReason.getReasonForCode(GattDisconnectReason.GATT_CONN_NO_RESOURCES.getCode()).ordinal());
+                builder.disconnectReason(GattDisconnectReason.GATT_CONN_NO_RESOURCES);
                 getGattServer().setState(GattState.ADD_SERVICE_FAILURE);
                 Timber.w("The gatt service %s, failed to be added at the gatt level, try again later.", service.getUuid());
                 builder.gattState(getGattServer().getGattState())
@@ -102,7 +103,7 @@ public class AddGattServerServiceTransaction extends GattServerTransaction {
     @Override
     public void onServerServiceAdded(int status, BluetoothGattService service) {
         TransactionResult.Builder builder = new TransactionResult.Builder().transactionName(getName());
-        builder.responseStatus(GattDisconnectReason.getReasonForCode(status).ordinal());
+        builder.responseStatus(GattStatus.getStatusForCode(status));
         if (status == BluetoothGatt.GATT_SUCCESS) {
             getGattServer().setState(GattState.ADD_SERVICE_SUCCESS);
             Timber.v("Gatt service was added to the gatt server successfully");

--- a/src/main/java/com/fitbit/bluetooth/fbgatt/tx/CreateBondTransaction.java
+++ b/src/main/java/com/fitbit/bluetooth/fbgatt/tx/CreateBondTransaction.java
@@ -177,7 +177,7 @@ public class CreateBondTransaction extends GattClientTransaction {
         getConnection().setState(GattState.CREATE_BOND_SUCCESS);
         builder.transactionName(NAME)
                 .gattState(getConnection().getGattState())
-                .responseStatus(GattStatus.GATT_SUCCESS.ordinal())
+                .responseStatus(GattStatus.GATT_SUCCESS)
                 .resultStatus(TransactionResult.TransactionResultStatus.SUCCESS);
         if (callback != null) {
             callCallbackWithTransactionResultAndRelease(callback, builder.build());
@@ -197,7 +197,7 @@ public class CreateBondTransaction extends GattClientTransaction {
         getConnection().setState(GattState.CREATE_BOND_FAILURE);
         builder.transactionName(NAME)
                 .gattState(getConnection().getGattState())
-                .responseStatus(GattStatus.GATT_INTERNAL_ERROR.ordinal())
+                .responseStatus(GattStatus.GATT_INTERNAL_ERROR)
                 .resultStatus(TransactionResult.TransactionResultStatus.FAILURE);
         if (callback != null) {
             callCallbackWithTransactionResultAndRelease(callback, builder.build());

--- a/src/main/java/com/fitbit/bluetooth/fbgatt/tx/GattClientDiscoverServicesTransaction.java
+++ b/src/main/java/com/fitbit/bluetooth/fbgatt/tx/GattClientDiscoverServicesTransaction.java
@@ -74,7 +74,7 @@ public class GattClientDiscoverServicesTransaction extends GattClientTransaction
     public void onServicesDiscovered(BluetoothGatt gatt, int status) {
         TransactionResult.Builder builder = new TransactionResult.Builder().transactionName(getName());
         builder.serverServices(gatt.getServices());
-        builder.responseStatus(GattStatus.getStatusForCode(status).ordinal());
+        builder.responseStatus(GattStatus.getStatusForCode(status));
         if(status == BluetoothGatt.GATT_SUCCESS) {
             getConnection().setState(GattState.DISCOVERY_SUCCESS);
             builder.resultStatus(TransactionResult.TransactionResultStatus.SUCCESS);

--- a/src/main/java/com/fitbit/bluetooth/fbgatt/tx/GattConnectTransaction.java
+++ b/src/main/java/com/fitbit/bluetooth/fbgatt/tx/GattConnectTransaction.java
@@ -56,7 +56,7 @@ public class GattConnectTransaction extends GattClientTransaction {
 
     private void failWithNoResources(){
         TransactionResult.Builder builder = new TransactionResult.Builder().transactionName(getName());
-        builder.responseStatus(GattStatus.GATT_NO_RESOURCES.getCode());
+        builder.responseStatus(GattStatus.GATT_NO_RESOURCES);
         getConnection().setState(GattState.DISCONNECTED);
         builder.rssi(getConnection().getDevice().getRssi())
                 .gattState(getConnection().getGattState())
@@ -77,7 +77,7 @@ public class GattConnectTransaction extends GattClientTransaction {
     @Override
     public void onConnectionStateChange(BluetoothGatt gatt, int status, int newState) {
         TransactionResult.Builder builder = new TransactionResult.Builder().transactionName(getName());
-        builder.responseStatus(GattDisconnectReason.getReasonForCode(newState).ordinal());
+        builder.disconnectReason(GattDisconnectReason.getReasonForCode(status));
         if(newState == BluetoothProfile.STATE_DISCONNECTED) {
             getConnection().setState(GattState.DISCONNECTED);
                     builder.rssi(getConnection().getDevice().getRssi())

--- a/src/main/java/com/fitbit/bluetooth/fbgatt/tx/GattDisconnectTransaction.java
+++ b/src/main/java/com/fitbit/bluetooth/fbgatt/tx/GattDisconnectTransaction.java
@@ -82,7 +82,7 @@ public class GattDisconnectTransaction extends GattClientTransaction {
     @Override
     public void onConnectionStateChange(BluetoothGatt gatt, int status, int newState) {
         TransactionResult.Builder builder = new TransactionResult.Builder().transactionName(getName());
-        builder.responseStatus(GattDisconnectReason.getReasonForCode(status).ordinal());
+        builder.disconnectReason(GattDisconnectReason.getReasonForCode(status));
         if(status != BluetoothGatt.GATT_SUCCESS) {
             Timber.e("[%s] The gatt connection changed in error", getDevice());
         }

--- a/src/main/java/com/fitbit/bluetooth/fbgatt/tx/GattServerDisconnectTransaction.java
+++ b/src/main/java/com/fitbit/bluetooth/fbgatt/tx/GattServerDisconnectTransaction.java
@@ -55,10 +55,10 @@ public class GattServerDisconnectTransaction extends GattServerTransaction {
 
     @Override
     public void onServerConnectionStateChange(BluetoothDevice device, int status, int newState) {
-        Timber.d("[%s] Gatt State %s, Disconnect Reason : %s", getDevice(), GattStatus.values()[status].name(),
-                GattDisconnectReason.getReasonForCode(newState));
+        Timber.d("[%s] Disconnect Reason %s, New State : %s", getDevice(), GattDisconnectReason.getReasonForCode(status).name(),
+                newState == BluetoothProfile.STATE_CONNECTED ? "Connected" : "Disconnected");
         TransactionResult.Builder builder = new TransactionResult.Builder().transactionName(getName());
-        builder.responseStatus(GattDisconnectReason.getReasonForCode(status).ordinal());
+        builder.disconnectReason(GattDisconnectReason.getReasonForCode(status));
         if (status == BluetoothGatt.GATT_SUCCESS) {
             if (newState == BluetoothProfile.STATE_DISCONNECTED) {
                 getGattServer().setState(GattState.DISCONNECTED);

--- a/src/main/java/com/fitbit/bluetooth/fbgatt/tx/NotifyGattServerCharacteristicTransaction.java
+++ b/src/main/java/com/fitbit/bluetooth/fbgatt/tx/NotifyGattServerCharacteristicTransaction.java
@@ -87,15 +87,15 @@ public class NotifyGattServerCharacteristicTransaction extends GattServerTransac
     }
 
     @Override
-    public void onServerNotificationSent(BluetoothDevice device, int status) {
-        Timber.d("[%s] Notification sent response with status: %s", getDevice(), GattStatus.values()[status].name());
+    public void onServerNotificationSent(BluetoothDevice device, GattStatus status) {
+        Timber.d("[%s] Notification sent response with status: %s", getDevice(), status.name());
         TransactionResult.Builder builder = new TransactionResult.Builder().transactionName(getName());
-        builder.responseStatus(GattDisconnectReason.getReasonForCode(status).ordinal());
+        builder.responseStatus(status);
         if(this.characteristic != null) {
             builder.characteristicUuid(this.characteristic.getUuid());
             builder.data(this.characteristic.getValue());
         }
-        if(status == BluetoothGatt.GATT_SUCCESS) {
+        if(status == GattStatus.GATT_SUCCESS) {
             getGattServer().setState(GattState.NOTIFY_CHARACTERISTIC_SUCCESS);
             builder.resultStatus(TransactionResult.TransactionResultStatus.SUCCESS);
             callCallbackWithTransactionResultAndRelease(callback, builder.build());

--- a/src/main/java/com/fitbit/bluetooth/fbgatt/tx/ReadGattCharacteristicTransaction.java
+++ b/src/main/java/com/fitbit/bluetooth/fbgatt/tx/ReadGattCharacteristicTransaction.java
@@ -18,6 +18,7 @@ import com.fitbit.bluetooth.fbgatt.TransactionResult;
 import com.fitbit.bluetooth.fbgatt.btcopies.BluetoothGattCharacteristicCopy;
 import com.fitbit.bluetooth.fbgatt.strategies.Strategy;
 import com.fitbit.bluetooth.fbgatt.util.GattDisconnectReason;
+import com.fitbit.bluetooth.fbgatt.util.GattStatus;
 
 import android.bluetooth.BluetoothGatt;
 import android.bluetooth.BluetoothGattCharacteristic;
@@ -95,7 +96,7 @@ public class ReadGattCharacteristicTransaction extends GattClientTransaction {
     @Override
     public void onCharacteristicRead(BluetoothGatt gatt, BluetoothGattCharacteristicCopy characteristic, int status) {
         TransactionResult.Builder builder = new TransactionResult.Builder().transactionName(getName());
-        builder.responseStatus(GattDisconnectReason.getReasonForCode(status).ordinal());
+        builder.responseStatus(GattStatus.getStatusForCode(status));
         if(status == BluetoothGatt.GATT_SUCCESS) {
             getConnection().setState(GattState.READ_CHARACTERISTIC_SUCCESS);
             builder.data(characteristic.getValue())

--- a/src/main/java/com/fitbit/bluetooth/fbgatt/tx/ReadGattClientPhyTransaction.java
+++ b/src/main/java/com/fitbit/bluetooth/fbgatt/tx/ReadGattClientPhyTransaction.java
@@ -16,6 +16,7 @@ import com.fitbit.bluetooth.fbgatt.GattTransaction;
 import com.fitbit.bluetooth.fbgatt.GattTransactionCallback;
 import com.fitbit.bluetooth.fbgatt.TransactionResult;
 import com.fitbit.bluetooth.fbgatt.util.GattDisconnectReason;
+import com.fitbit.bluetooth.fbgatt.util.GattStatus;
 
 import android.bluetooth.BluetoothGatt;
 
@@ -69,7 +70,7 @@ public class ReadGattClientPhyTransaction extends GattClientTransaction {
     public void onPhyRead(BluetoothGatt gatt, int txPhy, int rxPhy, int status) {
         Timber.i("[%s] The actual txPhy: %d, rxPhy: %d", getDevice(), txPhy, rxPhy);
         TransactionResult.Builder builder = new TransactionResult.Builder().transactionName(getName());
-        builder.responseStatus(GattDisconnectReason.getReasonForCode(status).ordinal());
+        builder.responseStatus(GattStatus.getStatusForCode(status));
         if(status == BluetoothGatt.GATT_SUCCESS) {
             getConnection().setState(GattState.READ_CURRENT_PHY_SUCCESS);
             builder.resultStatus(TransactionResult.TransactionResultStatus.SUCCESS)

--- a/src/main/java/com/fitbit/bluetooth/fbgatt/tx/ReadGattDescriptorTransaction.java
+++ b/src/main/java/com/fitbit/bluetooth/fbgatt/tx/ReadGattDescriptorTransaction.java
@@ -18,6 +18,7 @@ import com.fitbit.bluetooth.fbgatt.TransactionResult;
 import com.fitbit.bluetooth.fbgatt.btcopies.BluetoothGattDescriptorCopy;
 import com.fitbit.bluetooth.fbgatt.strategies.Strategy;
 import com.fitbit.bluetooth.fbgatt.util.GattDisconnectReason;
+import com.fitbit.bluetooth.fbgatt.util.GattStatus;
 
 import android.bluetooth.BluetoothGatt;
 import android.bluetooth.BluetoothGattDescriptor;
@@ -96,7 +97,7 @@ public class ReadGattDescriptorTransaction extends GattClientTransaction {
     @Override
     public void onDescriptorRead(BluetoothGatt gatt, BluetoothGattDescriptorCopy descriptor, int status) {
         TransactionResult.Builder builder = new TransactionResult.Builder().transactionName(getName());
-        builder.responseStatus(GattDisconnectReason.getReasonForCode(status).ordinal());
+        builder.responseStatus(GattStatus.getStatusForCode(status));
         if(status == BluetoothGatt.GATT_SUCCESS) {
             getConnection().setState(GattState.READ_DESCRIPTOR_SUCCESS);
             builder.resultStatus(TransactionResult.TransactionResultStatus.SUCCESS)

--- a/src/main/java/com/fitbit/bluetooth/fbgatt/tx/ReadGattServerCharacteristicDescriptorValueTransaction.java
+++ b/src/main/java/com/fitbit/bluetooth/fbgatt/tx/ReadGattServerCharacteristicDescriptorValueTransaction.java
@@ -69,7 +69,7 @@ public class ReadGattServerCharacteristicDescriptorValueTransaction extends Gatt
         byte[] value = localDescriptor.getValue();
         if(value != null) {
             // success
-            builder.responseStatus(GattStatus.GATT_SUCCESS.ordinal());
+            builder.responseStatus(GattStatus.GATT_SUCCESS);
                 getGattServer().setState(GattState.READ_DESCRIPTOR_SUCCESS);
                 builder.data(localCharacteristic.getValue())
                         .gattState(getGattServer().getGattState())
@@ -88,7 +88,7 @@ public class ReadGattServerCharacteristicDescriptorValueTransaction extends Gatt
 
     private void respondWithError(@Nullable BluetoothGattCharacteristic characteristic, @Nullable BluetoothGattDescriptor descriptor, GattTransactionCallback callback) {
         TransactionResult.Builder builder = new TransactionResult.Builder().transactionName(getName());
-        builder.responseStatus(GattStatus.GATT_ERROR.ordinal());
+        builder.responseStatus(GattStatus.GATT_ERROR);
         getGattServer().setState(GattState.READ_DESCRIPTOR_FAILURE);
         builder.data(descriptor == null ? new byte[0] : descriptor.getValue())
                 .gattState(getGattServer().getGattState())

--- a/src/main/java/com/fitbit/bluetooth/fbgatt/tx/ReadGattServerCharacteristicValueTransaction.java
+++ b/src/main/java/com/fitbit/bluetooth/fbgatt/tx/ReadGattServerCharacteristicValueTransaction.java
@@ -58,7 +58,7 @@ public class ReadGattServerCharacteristicValueTransaction extends GattServerTran
         byte[] value = localCharacteristic.getValue();
         if(null != value) {
             // success
-            builder.responseStatus(GattStatus.GATT_SUCCESS.ordinal());
+            builder.responseStatus(GattStatus.GATT_SUCCESS);
                 getGattServer().setState(GattState.READ_CHARACTERISTIC_SUCCESS);
                 builder.data(value)
                         .gattState(getGattServer().getGattState())
@@ -75,7 +75,7 @@ public class ReadGattServerCharacteristicValueTransaction extends GattServerTran
 
     private void respondWithError(@Nullable BluetoothGattCharacteristic characteristic, GattTransactionCallback callback) {
         TransactionResult.Builder builder = new TransactionResult.Builder().transactionName(getName());
-        builder.responseStatus(GattStatus.GATT_ERROR.ordinal());
+        builder.responseStatus(GattStatus.GATT_ERROR);
         getGattServer().setState(GattState.READ_CHARACTERISTIC_FAILURE);
         builder.data(characteristic == null ? new byte[0] : characteristic.getValue())
                 .gattState(getGattServer().getGattState())

--- a/src/main/java/com/fitbit/bluetooth/fbgatt/tx/ReadRssiTransaction.java
+++ b/src/main/java/com/fitbit/bluetooth/fbgatt/tx/ReadRssiTransaction.java
@@ -18,6 +18,7 @@ import com.fitbit.bluetooth.fbgatt.GattTransaction;
 import com.fitbit.bluetooth.fbgatt.GattTransactionCallback;
 import com.fitbit.bluetooth.fbgatt.TransactionResult;
 import com.fitbit.bluetooth.fbgatt.util.GattDisconnectReason;
+import com.fitbit.bluetooth.fbgatt.util.GattStatus;
 
 /**
  * To read the RSSI from a remote device
@@ -61,7 +62,7 @@ public class ReadRssiTransaction extends GattClientTransaction {
     @Override
     public void onReadRemoteRssi(BluetoothGatt gatt, int rssi, int status) {
         TransactionResult.Builder builder = new TransactionResult.Builder().transactionName(getName());
-        builder.responseStatus(GattDisconnectReason.getReasonForCode(status).ordinal());
+        builder.responseStatus(GattStatus.getStatusForCode(status));
         if(status == BluetoothGatt.GATT_SUCCESS) {
             getConnection().setState(GattState.READ_RSSI_SUCCESS);
             getConnection().getDevice().setRssi(rssi);

--- a/src/main/java/com/fitbit/bluetooth/fbgatt/tx/RequestGattClientPhyChangeTransaction.java
+++ b/src/main/java/com/fitbit/bluetooth/fbgatt/tx/RequestGattClientPhyChangeTransaction.java
@@ -16,6 +16,7 @@ import com.fitbit.bluetooth.fbgatt.GattTransaction;
 import com.fitbit.bluetooth.fbgatt.GattTransactionCallback;
 import com.fitbit.bluetooth.fbgatt.TransactionResult;
 import com.fitbit.bluetooth.fbgatt.util.GattDisconnectReason;
+import com.fitbit.bluetooth.fbgatt.util.GattStatus;
 
 import android.bluetooth.BluetoothGatt;
 
@@ -78,7 +79,7 @@ public class RequestGattClientPhyChangeTransaction extends GattClientTransaction
     @Override
     public void onPhyUpdate(BluetoothGatt gatt, int txPhy, int rxPhy, int status) {
         TransactionResult.Builder builder = new TransactionResult.Builder().transactionName(getName());
-        builder.responseStatus(GattDisconnectReason.getReasonForCode(status).ordinal());
+        builder.responseStatus(GattStatus.getStatusForCode(status));
         if(status == BluetoothGatt.GATT_SUCCESS) {
             getConnection().setState(GattState.REQUEST_PHY_CHANGE_SUCCESS);
             builder.resultStatus(TransactionResult.TransactionResultStatus.SUCCESS)

--- a/src/main/java/com/fitbit/bluetooth/fbgatt/tx/RequestGattConnectionIntervalTransaction.java
+++ b/src/main/java/com/fitbit/bluetooth/fbgatt/tx/RequestGattConnectionIntervalTransaction.java
@@ -83,7 +83,7 @@ public class RequestGattConnectionIntervalTransaction extends GattClientTransact
             }
             if(!success) {
                 getConnection().setState(GattState.REQUEST_CONNECTION_INTERVAL_FAILURE);
-                builder.responseStatus(GattStatus.GATT_NO_RESOURCES.getCode());
+                builder.responseStatus(GattStatus.GATT_NO_RESOURCES);
                 builder.gattState(getConnection().getGattState());
                 mainThreadHandler.post(() -> {
                     callCallbackWithTransactionResultAndRelease(callback, builder.build());
@@ -102,7 +102,7 @@ public class RequestGattConnectionIntervalTransaction extends GattClientTransact
             }
         } else {
             getConnection().setState(GattState.REQUEST_CONNECTION_INTERVAL_FAILURE);
-            builder.responseStatus(GattStatus.GATT_NO_RESOURCES.getCode());
+            builder.responseStatus(GattStatus.GATT_NO_RESOURCES);
             builder.gattState(getConnection().getGattState());
             mainThreadHandler.post(() -> {
                 callCallbackWithTransactionResultAndRelease(callback, builder.build());

--- a/src/main/java/com/fitbit/bluetooth/fbgatt/tx/RequestMtuGattTransaction.java
+++ b/src/main/java/com/fitbit/bluetooth/fbgatt/tx/RequestMtuGattTransaction.java
@@ -16,6 +16,7 @@ import com.fitbit.bluetooth.fbgatt.GattTransaction;
 import com.fitbit.bluetooth.fbgatt.GattTransactionCallback;
 import com.fitbit.bluetooth.fbgatt.TransactionResult;
 import com.fitbit.bluetooth.fbgatt.util.GattDisconnectReason;
+import com.fitbit.bluetooth.fbgatt.util.GattStatus;
 
 import android.bluetooth.BluetoothGatt;
 import androidx.annotation.Nullable;
@@ -77,7 +78,7 @@ public class RequestMtuGattTransaction extends GattClientTransaction {
     @Override
     public void onMtuChanged(BluetoothGatt gatt, int mtu, int status) {
         TransactionResult.Builder builder = new TransactionResult.Builder().transactionName(getName());
-        builder.responseStatus(GattDisconnectReason.getReasonForCode(status).ordinal());
+        builder.responseStatus(GattStatus.getStatusForCode(status));
         if(status == BluetoothGatt.GATT_SUCCESS) {
             getConnection().setState(GattState.REQUEST_MTU_SUCCESS);
             builder.resultStatus(TransactionResult.TransactionResultStatus.SUCCESS)

--- a/src/main/java/com/fitbit/bluetooth/fbgatt/tx/SendGattServerResponseTransaction.java
+++ b/src/main/java/com/fitbit/bluetooth/fbgatt/tx/SendGattServerResponseTransaction.java
@@ -73,7 +73,7 @@ public class SendGattServerResponseTransaction extends GattServerTransaction {
             getGattServer().setState(GattState.SEND_SERVER_RESPONSE_SUCCESS);
             builder.gattState(getGattServer().getGattState());
             builder.resultStatus(TransactionResult.TransactionResultStatus.SUCCESS);
-            builder.responseStatus(GattStatus.getStatusForCode(status).ordinal());
+            builder.responseStatus(GattStatus.getStatusForCode(status));
             builder.data(value).
                     requestId(requestId).
                     offset(offset);
@@ -85,7 +85,7 @@ public class SendGattServerResponseTransaction extends GattServerTransaction {
             getGattServer().setState(GattState.SEND_SERVER_RESPONSE_FAILURE);
             builder.gattState(getGattServer().getGattState());
             builder.resultStatus(TransactionResult.TransactionResultStatus.FAILURE);
-            builder.responseStatus(GattStatus.getStatusForCode(status).ordinal());
+            builder.responseStatus(GattStatus.getStatusForCode(status));
             builder.data(value).
                     requestId(requestId).
                     offset(offset);

--- a/src/main/java/com/fitbit/bluetooth/fbgatt/tx/SubscribeToCharacteristicNotificationsTransaction.java
+++ b/src/main/java/com/fitbit/bluetooth/fbgatt/tx/SubscribeToCharacteristicNotificationsTransaction.java
@@ -57,7 +57,7 @@ public class SubscribeToCharacteristicNotificationsTransaction extends GattClien
             getConnection().setState(GattState.ENABLE_CHARACTERISTIC_NOTIFICATION_FAILURE);
             builder.characteristicUuid(characteristic.getUuid())
                 .gattState(getConnection().getGattState())
-                .responseStatus(GattStatus.GATT_UNKNOWN.ordinal())
+                .responseStatus(GattStatus.GATT_UNKNOWN)
                 .resultStatus(TransactionResult.TransactionResultStatus.FAILURE)
                 .data(characteristic.getValue())
                 .serviceUuid(characteristic.getService().getUuid());
@@ -70,14 +70,14 @@ public class SubscribeToCharacteristicNotificationsTransaction extends GattClien
                 builder.characteristicUuid(characteristic.getUuid())
                         .gattState(getConnection().getGattState())
                         .resultStatus(TransactionResult.TransactionResultStatus.SUCCESS)
-                        .responseStatus(GattStatus.GATT_SUCCESS.ordinal())
+                        .responseStatus(GattStatus.GATT_SUCCESS)
                         .data(characteristic.getValue())
                         .serviceUuid(characteristic.getService().getUuid());
             } else {
                 getConnection().setState(GattState.ENABLE_CHARACTERISTIC_NOTIFICATION_FAILURE);
                 builder.characteristicUuid(characteristic.getUuid())
                         .gattState(getConnection().getGattState())
-                        .responseStatus(GattStatus.GATT_UNKNOWN.ordinal())
+                        .responseStatus(GattStatus.GATT_UNKNOWN)
                         .resultStatus(TransactionResult.TransactionResultStatus.FAILURE)
                         .data(characteristic.getValue())
                         .serviceUuid(characteristic.getService().getUuid());
@@ -110,11 +110,10 @@ public class SubscribeToCharacteristicNotificationsTransaction extends GattClien
             // we want to apply this strategy to every phone, so we will provide an empty target android
             // device
             getConnection().setState(GattState.ENABLE_CHARACTERISTIC_NOTIFICATION_FAILURE);
-            builder.responseStatus(GattDisconnectReason.getReasonForCode(GattStatus.GATT_UNKNOWN.getCode()).ordinal())
-                    .characteristicUuid(characteristic.getUuid())
+            builder.characteristicUuid(characteristic.getUuid())
                     .resultStatus(TransactionResult.TransactionResultStatus.FAILURE)
                     .gattState(getConnection().getGattState())
-                    .responseStatus(GattStatus.GATT_UNKNOWN.ordinal())
+                    .responseStatus(GattStatus.GATT_UNKNOWN)
                     .data(characteristic.getValue())
                     .serviceUuid(characteristic.getService().getUuid());
             mainThreadHandler.post(() -> {

--- a/src/main/java/com/fitbit/bluetooth/fbgatt/tx/UnSubscribeToGattCharacteristicNotificationsTransaction.java
+++ b/src/main/java/com/fitbit/bluetooth/fbgatt/tx/UnSubscribeToGattCharacteristicNotificationsTransaction.java
@@ -108,11 +108,10 @@ public class UnSubscribeToGattCharacteristicNotificationsTransaction extends Gat
         } else {
             // no need for strategy, it failed.
             getConnection().setState(GattState.DISABLE_CHARACTERISTIC_NOTIFICATION_FAILURE);
-            builder.responseStatus(GattDisconnectReason.getReasonForCode(GattStatus.GATT_UNKNOWN.getCode()).ordinal())
-                    .characteristicUuid(characteristic.getUuid())
+            builder.characteristicUuid(characteristic.getUuid())
                     .resultStatus(TransactionResult.TransactionResultStatus.FAILURE)
                     .gattState(getConnection().getGattState())
-                    .responseStatus(GattStatus.GATT_UNKNOWN.ordinal())
+                    .responseStatus(GattStatus.GATT_UNKNOWN)
                     .data(characteristic.getValue())
                     .serviceUuid(characteristic.getService().getUuid());
             mainThreadHandler.post(() -> {

--- a/src/main/java/com/fitbit/bluetooth/fbgatt/tx/WriteGattCharacteristicTransaction.java
+++ b/src/main/java/com/fitbit/bluetooth/fbgatt/tx/WriteGattCharacteristicTransaction.java
@@ -18,6 +18,7 @@ import com.fitbit.bluetooth.fbgatt.TransactionResult;
 import com.fitbit.bluetooth.fbgatt.btcopies.BluetoothGattCharacteristicCopy;
 import com.fitbit.bluetooth.fbgatt.strategies.Strategy;
 import com.fitbit.bluetooth.fbgatt.util.GattDisconnectReason;
+import com.fitbit.bluetooth.fbgatt.util.GattStatus;
 
 import android.bluetooth.BluetoothGatt;
 import android.bluetooth.BluetoothGattCharacteristic;
@@ -93,7 +94,7 @@ public class WriteGattCharacteristicTransaction extends GattClientTransaction {
     @Override
     public void onCharacteristicWrite(BluetoothGatt gatt, BluetoothGattCharacteristicCopy characteristic, int status) {
         TransactionResult.Builder builder = new TransactionResult.Builder().transactionName(getName());
-        builder.responseStatus(GattDisconnectReason.getReasonForCode(status).ordinal());
+        builder.responseStatus(GattStatus.getStatusForCode(status));
         if (status == BluetoothGatt.GATT_SUCCESS) {
             getConnection().setState(GattState.WRITE_CHARACTERISTIC_SUCCESS);
             builder.data(characteristic.getValue())

--- a/src/main/java/com/fitbit/bluetooth/fbgatt/tx/WriteGattDescriptorTransaction.java
+++ b/src/main/java/com/fitbit/bluetooth/fbgatt/tx/WriteGattDescriptorTransaction.java
@@ -18,6 +18,7 @@ import com.fitbit.bluetooth.fbgatt.TransactionResult;
 import com.fitbit.bluetooth.fbgatt.btcopies.BluetoothGattDescriptorCopy;
 import com.fitbit.bluetooth.fbgatt.strategies.Strategy;
 import com.fitbit.bluetooth.fbgatt.util.GattDisconnectReason;
+import com.fitbit.bluetooth.fbgatt.util.GattStatus;
 
 import android.bluetooth.BluetoothGatt;
 import android.bluetooth.BluetoothGattDescriptor;
@@ -92,7 +93,7 @@ public class WriteGattDescriptorTransaction extends GattClientTransaction {
     @Override
     public void onDescriptorWrite(BluetoothGatt gatt, BluetoothGattDescriptorCopy descriptor, int status) {
         TransactionResult.Builder builder = new TransactionResult.Builder().transactionName(getName());
-        builder.responseStatus(GattDisconnectReason.getReasonForCode(status).ordinal());
+        builder.responseStatus(GattStatus.getStatusForCode(status));
         if (status == BluetoothGatt.GATT_SUCCESS) {
             getConnection().setState(GattState.WRITE_DESCRIPTOR_SUCCESS);
             builder.descriptorUuid(descriptor.getUuid())

--- a/src/main/java/com/fitbit/bluetooth/fbgatt/tx/WriteGattServerCharacteristicDescriptorValueTransaction.java
+++ b/src/main/java/com/fitbit/bluetooth/fbgatt/tx/WriteGattServerCharacteristicDescriptorValueTransaction.java
@@ -76,7 +76,7 @@ public class WriteGattServerCharacteristicDescriptorValueTransaction extends Gat
         try {
             if (localDescriptor.setValue(data)) {
                 // success
-                builder.responseStatus(GattStatus.GATT_SUCCESS.ordinal());
+                builder.responseStatus(GattStatus.GATT_SUCCESS);
                 getGattServer().setState(GattState.WRITE_DESCRIPTOR_SUCCESS);
                 builder.data(localCharacteristic.getValue())
                         .gattState(getGattServer().getGattState())
@@ -104,7 +104,7 @@ public class WriteGattServerCharacteristicDescriptorValueTransaction extends Gat
 
     private void respondWithError(@Nullable BluetoothGattCharacteristic characteristic, @Nullable BluetoothGattDescriptor descriptor, GattTransactionCallback callback) {
         TransactionResult.Builder builder = new TransactionResult.Builder().transactionName(getName());
-        builder.responseStatus(GattStatus.GATT_ERROR.ordinal());
+        builder.responseStatus(GattStatus.GATT_ERROR);
         getGattServer().setState(GattState.WRITE_DESCRIPTOR_FAILURE);
         builder.data(descriptor == null ? new byte[0] : descriptor.getValue())
                 .gattState(getGattServer().getGattState())

--- a/src/main/java/com/fitbit/bluetooth/fbgatt/tx/WriteGattServerCharacteristicValueTransaction.java
+++ b/src/main/java/com/fitbit/bluetooth/fbgatt/tx/WriteGattServerCharacteristicValueTransaction.java
@@ -65,7 +65,7 @@ public class WriteGattServerCharacteristicValueTransaction extends GattServerTra
         try {
             if (localCharacteristic.setValue(data)) {
                 // success
-                builder.responseStatus(GattStatus.GATT_SUCCESS.ordinal());
+                builder.responseStatus(GattStatus.GATT_SUCCESS);
                 getGattServer().setState(GattState.WRITE_CHARACTERISTIC_SUCCESS);
                 builder.data(localCharacteristic.getValue())
                         .gattState(getGattServer().getGattState())
@@ -92,7 +92,7 @@ public class WriteGattServerCharacteristicValueTransaction extends GattServerTra
 
     private void respondWithError(@Nullable BluetoothGattCharacteristic characteristic, GattTransactionCallback callback) {
         TransactionResult.Builder builder = new TransactionResult.Builder().transactionName(getName());
-        builder.responseStatus(GattStatus.GATT_ERROR.ordinal());
+        builder.responseStatus(GattStatus.GATT_ERROR);
         getGattServer().setState(GattState.WRITE_CHARACTERISTIC_FAILURE);
         builder.data(characteristic == null ? new byte[0] : characteristic.getValue())
                 .gattState(getGattServer().getGattState())

--- a/src/main/java/com/fitbit/bluetooth/fbgatt/tx/mocks/GattClientDiscoverMockServicesTransaction.java
+++ b/src/main/java/com/fitbit/bluetooth/fbgatt/tx/mocks/GattClientDiscoverMockServicesTransaction.java
@@ -47,13 +47,13 @@ public class GattClientDiscoverMockServicesTransaction extends GattClientDiscove
             TransactionResult.Builder builder = new TransactionResult.Builder().transactionName(getName());
             if(shouldFail) {
                 getConnection().setState(GattState.DISCOVERY_FAILURE);
-                builder.responseStatus(GattStatus.GATT_ERROR.ordinal());
+                builder.responseStatus(GattStatus.GATT_ERROR);
                 builder.resultStatus(TransactionResult.TransactionResultStatus.FAILURE);
                 builder.gattState(getConnection().getGattState());
                 callCallbackWithTransactionResultAndRelease(callback, builder.build());
             } else {
                 getConnection().setState(GattState.DISCOVERY_FAILURE);
-                builder.responseStatus(GattStatus.GATT_SUCCESS.ordinal());
+                builder.responseStatus(GattStatus.GATT_SUCCESS);
                 builder.resultStatus(TransactionResult.TransactionResultStatus.SUCCESS);
                 builder.serverServices(this.services);
                 builder.gattState(getConnection().getGattState());

--- a/src/main/java/com/fitbit/bluetooth/fbgatt/tx/mocks/GattConnectMockTransaction.java
+++ b/src/main/java/com/fitbit/bluetooth/fbgatt/tx/mocks/GattConnectMockTransaction.java
@@ -49,17 +49,16 @@ public class GattConnectMockTransaction extends GattConnectTransaction {
         getConnection().setState(GattState.CONNECTING);
         mainHandler.postDelayed(() -> {
             TransactionResult.Builder builder = new TransactionResult.Builder().transactionName(getName());
-            builder.responseStatus(GattDisconnectReason.getReasonForCode(shouldFail ? BluetoothGatt.GATT_FAILURE : BluetoothGatt.GATT_SUCCESS).ordinal());
+            builder.responseStatus(shouldFail ? GattStatus.GATT_UNKNOWN : GattStatus.GATT_SUCCESS);
             if(shouldFail) {
                 getConnection().setState(GattState.DISCONNECTED);
-                builder.responseStatus(GattDisconnectReason.GATT_CONN_TIMEOUT.getCode())
+                builder.disconnectReason(GattDisconnectReason.GATT_CONN_TIMEOUT)
                         .gattState(getConnection().getGattState())
                         .resultStatus(TransactionResult.TransactionResultStatus.FAILURE);
                 callCallbackWithTransactionResultAndRelease(callback, builder.build());
             } else {
                 getConnection().setState(GattState.CONNECTED);
                 builder.gattState(getConnection().getGattState())
-                        .responseStatus(0)
                         .resultStatus(TransactionResult.TransactionResultStatus.SUCCESS);
                 callCallbackWithTransactionResultAndRelease(callback, builder.build());
                 getConnection().setState(GattState.IDLE);
@@ -69,7 +68,7 @@ public class GattConnectMockTransaction extends GattConnectTransaction {
 
     private void failWithNoResources(){
         TransactionResult.Builder builder = new TransactionResult.Builder().transactionName(getName());
-        builder.responseStatus(GattStatus.GATT_NO_RESOURCES.getCode());
+        builder.responseStatus(GattStatus.GATT_NO_RESOURCES);
         getConnection().setState(GattState.DISCONNECTED);
         builder.rssi(getConnection().getDevice().getRssi())
                 .gattState(getConnection().getGattState())

--- a/src/main/java/com/fitbit/bluetooth/fbgatt/tx/mocks/GattDisconnectMockTransaction.java
+++ b/src/main/java/com/fitbit/bluetooth/fbgatt/tx/mocks/GattDisconnectMockTransaction.java
@@ -17,6 +17,7 @@ import com.fitbit.bluetooth.fbgatt.GattTransactionCallback;
 import com.fitbit.bluetooth.fbgatt.TransactionResult;
 import com.fitbit.bluetooth.fbgatt.tx.GattDisconnectTransaction;
 import com.fitbit.bluetooth.fbgatt.util.GattDisconnectReason;
+import com.fitbit.bluetooth.fbgatt.util.GattStatus;
 
 import java.util.concurrent.TimeUnit;
 
@@ -45,17 +46,16 @@ public class GattDisconnectMockTransaction extends GattDisconnectTransaction {
         this.callback = callback;
         mainHandler.postDelayed(() -> {
             TransactionResult.Builder builder = new TransactionResult.Builder().transactionName(getName());
-            builder.responseStatus(GattDisconnectReason.getReasonForCode(shouldFail ? BluetoothGatt.GATT_FAILURE : BluetoothGatt.GATT_SUCCESS).ordinal());
+            builder.responseStatus(shouldFail ? GattStatus.GATT_UNKNOWN : GattStatus.GATT_SUCCESS);
             if(shouldFail) {
                 getConnection().setState(GattState.CONNECTED);
-                builder.responseStatus(GattDisconnectReason.GATT_CONN_TIMEOUT.getCode())
+                builder.disconnectReason(GattDisconnectReason.GATT_CONN_TIMEOUT)
                         .gattState(getConnection().getGattState())
                         .resultStatus(TransactionResult.TransactionResultStatus.FAILURE);
                 callCallbackWithTransactionResultAndRelease(callback, builder.build());
             } else {
                 getConnection().setState(GattState.DISCONNECTED);
                 builder.gattState(getConnection().getGattState())
-                        .responseStatus(0)
                         .resultStatus(TransactionResult.TransactionResultStatus.SUCCESS);
                 callCallbackWithTransactionResultAndRelease(callback, builder.build());
             }

--- a/src/main/java/com/fitbit/bluetooth/fbgatt/tx/mocks/GattServerConnectMockTransaction.java
+++ b/src/main/java/com/fitbit/bluetooth/fbgatt/tx/mocks/GattServerConnectMockTransaction.java
@@ -15,6 +15,7 @@ import com.fitbit.bluetooth.fbgatt.GattTransactionCallback;
 import com.fitbit.bluetooth.fbgatt.TransactionResult;
 import com.fitbit.bluetooth.fbgatt.tx.GattServerConnectTransaction;
 import com.fitbit.bluetooth.fbgatt.util.GattDisconnectReason;
+import com.fitbit.bluetooth.fbgatt.util.GattStatus;
 
 import android.bluetooth.BluetoothGatt;
 import android.os.Handler;
@@ -41,7 +42,7 @@ public class GattServerConnectMockTransaction extends GattServerConnectTransacti
         getGattServer().setState(GattState.CONNECTING);
         mainHandler.postDelayed(() -> {
             TransactionResult.Builder builder = new TransactionResult.Builder().transactionName(getName());
-            builder.responseStatus(GattDisconnectReason.getReasonForCode(shouldFail ? BluetoothGatt.GATT_FAILURE : BluetoothGatt.GATT_SUCCESS).ordinal());
+            builder.responseStatus(shouldFail ? GattStatus.GATT_UNKNOWN : GattStatus.GATT_SUCCESS);
             if(shouldFail) {
                 getGattServer().setState(GattState.FAILURE_CONNECTING);
                 builder.resultStatus(TransactionResult.TransactionResultStatus.FAILURE)

--- a/src/main/java/com/fitbit/bluetooth/fbgatt/tx/mocks/NotifyGattServerCharacteristicMockTransaction.java
+++ b/src/main/java/com/fitbit/bluetooth/fbgatt/tx/mocks/NotifyGattServerCharacteristicMockTransaction.java
@@ -55,7 +55,7 @@ public class NotifyGattServerCharacteristicMockTransaction extends NotifyGattSer
                     // we want to apply this strategy to every phone, so we will provide an empty target android
                     // device
                     TransactionResult.Builder builder = new TransactionResult.Builder().transactionName(getName());
-                    builder.responseStatus(GattDisconnectReason.getReasonForCode(GattStatus.GATT_INTERNAL_ERROR.getCode()).ordinal());
+                    builder.responseStatus(GattStatus.GATT_INTERNAL_ERROR);
                     if(this.characteristic != null) {
                         builder.characteristicUuid(this.characteristic.getUuid());
                         builder.data(this.characteristic.getValue());
@@ -71,10 +71,10 @@ public class NotifyGattServerCharacteristicMockTransaction extends NotifyGattSer
                     }
                     callCallbackWithTransactionResultAndRelease(callback, builder.build());
                 } else {
-                    onServerNotificationSent(null, GattStatus.GATT_INTERNAL_ERROR.ordinal());
+                    onServerNotificationSent(null, GattStatus.GATT_INTERNAL_ERROR);
                 }
             } else {
-                onServerNotificationSent(null, BluetoothGatt.GATT_SUCCESS);
+                onServerNotificationSent(null, GattStatus.GATT_SUCCESS);
             }
         }, REASONABLE_AMOUNT_OF_TIME_FOR_NOTIFY);
     }

--- a/src/main/java/com/fitbit/bluetooth/fbgatt/tx/mocks/RequestGattConnectionIntervalMockTransaction.java
+++ b/src/main/java/com/fitbit/bluetooth/fbgatt/tx/mocks/RequestGattConnectionIntervalMockTransaction.java
@@ -49,7 +49,7 @@ public class RequestGattConnectionIntervalMockTransaction extends RequestGattCon
                 callCallbackWithTransactionResultAndRelease(callback, new TransactionResult.Builder().
                         transactionName(getName()).
                         resultStatus(TransactionResult.TransactionResultStatus.FAILURE).
-                        responseStatus(GattStatus.GATT_INSUF_RESOURCE.getCode()).build());
+                        responseStatus(GattStatus.GATT_INSUF_RESOURCE).build());
             } else {
                 callCallbackWithTransactionResultAndRelease(callback, new TransactionResult.Builder().
                         transactionName(getName()).

--- a/src/test/java/com/fitbit/bluetooth/fbgatt/GattServerTests.java
+++ b/src/test/java/com/fitbit/bluetooth/fbgatt/GattServerTests.java
@@ -14,6 +14,7 @@ import com.fitbit.bluetooth.fbgatt.tx.mocks.AddGattServerServiceMockTransaction;
 import com.fitbit.bluetooth.fbgatt.tx.mocks.SendGattServerResponseMockTransaction;
 import com.fitbit.bluetooth.fbgatt.util.BluetoothManagerProvider;
 import com.fitbit.bluetooth.fbgatt.util.BluetoothUtils;
+import com.fitbit.bluetooth.fbgatt.util.GattStatus;
 import com.fitbit.bluetooth.fbgatt.util.LooperWatchdog;
 
 import android.bluetooth.BluetoothAdapter;
@@ -159,7 +160,7 @@ public class GattServerTests {
             }
 
             @Override
-            public void onServerNotificationSent(BluetoothDevice device, int status) {
+            public void onServerNotificationSent(BluetoothDevice device, GattStatus status) {
 
             }
 


### PR DESCRIPTION
# Fixes #

### description
TransactionResult.responseStatus was used to hold ordinals from both GattStatus and GattDisconnectReason enums, which created ambiguity about its meaning. Also, sometimes the "code" was passed in instead of the ordinal, creating an incorrect mapping.

Furthermore, there are 2 GattDisconnectReason enums, one of which appears to be a superset of the other.

### changes
- Changed the type of responseStatus to GattStatus to enforce type safety
- Added a disconnectReason field to TransactionResult to carry this information as well
- Marked the less complete GattDisconnectReason as `@Deprecated`
- Tried to use the correct enum that corresponds to the namespace of the `status` argument in each callback. Definitely could have made a mistake here as it's not always easy to tell.

### how tested
No changes to bluetooth behavior, so I didn't test it. 
