### PR TITLE
Fix for bond denial failure

### DIFF
--- a/src/main/java/com/fitbit/bluetooth/fbgatt/GattClientTransaction.java
+++ b/src/main/java/com/fitbit/bluetooth/fbgatt/GattClientTransaction.java
@@ -10,11 +10,12 @@ package com.fitbit.bluetooth.fbgatt;
 import com.fitbit.bluetooth.fbgatt.btcopies.BluetoothGattCharacteristicCopy;
 import com.fitbit.bluetooth.fbgatt.btcopies.BluetoothGattDescriptorCopy;
 import com.fitbit.bluetooth.fbgatt.util.GattUtils;
+
 import android.bluetooth.BluetoothGatt;
 import android.os.Looper;
-import java.util.ArrayList;
+
 import java.util.Locale;
-import java.util.concurrent.TimeUnit;
+
 import androidx.annotation.Nullable;
 import androidx.annotation.VisibleForTesting;
 import timber.log.Timber;
@@ -26,7 +27,7 @@ import timber.log.Timber;
  * {@link GattClientTransaction} registration lifecycle
  */
 public class GattClientTransaction extends GattTransaction<GattClientTransaction> implements GattClientListener {
-    private GattUtils utils = new GattUtils();
+    private final GattUtils utils = new GattUtils();
     private final GattConnection connection;
 
     public GattClientTransaction(@Nullable GattConnection connection, GattState successEndState) {
@@ -40,7 +41,7 @@ public class GattClientTransaction extends GattTransaction<GattClientTransaction
         setTimeout(timeoutMillis);
     }
 
-    protected GattConnection getConnection() {
+    public GattConnection getConnection() {
         return connection;
     }
 

--- a/src/main/java/com/fitbit/bluetooth/fbgatt/receivers/CreateBondTransactionBroadcastReceiver.java
+++ b/src/main/java/com/fitbit/bluetooth/fbgatt/receivers/CreateBondTransactionBroadcastReceiver.java
@@ -61,7 +61,10 @@ public class CreateBondTransactionBroadcastReceiver extends BroadcastReceiver {
                         Timber.w("[%s] Bond state changed to NONE", createBondTransactionInterface.getDevice());
                         // if we are here, we should go ahead and release the lock
                         // failure
-                        createBondTransactionInterface.bondFailure();
+                        if (newState != oldState) {
+                            //  Only notify failures for different states.
+                            createBondTransactionInterface.bondFailure();
+                        }
                         break;
                     case BluetoothDevice.BOND_BONDING:
                         Timber.d("[%s] Bond state changed to BONDING", createBondTransactionInterface.getDevice());

--- a/src/main/java/com/fitbit/bluetooth/fbgatt/receivers/CreateBondTransactionBroadcastReceiver.java
+++ b/src/main/java/com/fitbit/bluetooth/fbgatt/receivers/CreateBondTransactionBroadcastReceiver.java
@@ -1,0 +1,77 @@
+package com.fitbit.bluetooth.fbgatt.receivers;
+
+import com.fitbit.bluetooth.fbgatt.tx.CreateBondTransactionInterface;
+import com.fitbit.bluetooth.fbgatt.util.BluetoothDeviceProvider;
+import com.fitbit.bluetooth.fbgatt.util.BluetoothDeviceProviderInterface;
+import com.fitbit.bluetooth.fbgatt.util.DeviceMatcher;
+import com.fitbit.bluetooth.fbgatt.util.GattUtils;
+
+import android.bluetooth.BluetoothDevice;
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+
+import timber.log.Timber;
+
+public class CreateBondTransactionBroadcastReceiver extends BroadcastReceiver {
+    private final CreateBondTransactionInterface createBondTransactionInterface;
+    private final GattUtils gattUtils;
+    private final BluetoothDeviceProviderInterface deviceProvider;
+    private final DeviceMatcher deviceMatcher;
+
+    public CreateBondTransactionBroadcastReceiver(CreateBondTransactionInterface createBondTransactionInterface) {
+        this(createBondTransactionInterface, new GattUtils(), new BluetoothDeviceProvider(), new DeviceMatcher());
+    }
+
+    public CreateBondTransactionBroadcastReceiver(CreateBondTransactionInterface createBondTransactionInterface, GattUtils gattUtils, BluetoothDeviceProviderInterface deviceProvider, DeviceMatcher deviceMatcher) {
+        this.createBondTransactionInterface = createBondTransactionInterface;
+        this.gattUtils = gattUtils;
+        this.deviceProvider = deviceProvider;
+        this.deviceMatcher = deviceMatcher;
+    }
+
+    @Override
+    public void onReceive(Context context, Intent intent) {
+        if (BluetoothDevice.ACTION_BOND_STATE_CHANGED.equals(intent.getAction())) {
+            BluetoothDevice extraDevice = deviceProvider.getFromIntent(intent);
+            /*
+             * equals handled inside of {@link FitbitBluetoothDevice} for comparison to an
+             * {@link BluetoothDevice}
+             */
+            //noinspection EqualsBetweenInconvertibleTypes
+            if (deviceMatcher.matchDevices(createBondTransactionInterface.getDevice(), extraDevice)) {
+                int oldState = intent.getIntExtra(BluetoothDevice.EXTRA_PREVIOUS_BOND_STATE, BluetoothDevice.BOND_NONE);
+                int newState = intent.getIntExtra(BluetoothDevice.EXTRA_BOND_STATE, BluetoothDevice.BOND_NONE);
+                Timber.d("[%s] Bond state changed from %s to %s",
+                    createBondTransactionInterface.getDevice(),
+                    gattUtils.getBondStateDescription(oldState),
+                    gattUtils.getBondStateDescription(newState));
+                switch (newState) {
+                    case BluetoothDevice.BOND_BONDED:
+                        Timber.d("[%s] Bond state changed to BONDED", createBondTransactionInterface.getDevice());
+                        // success
+                        createBondTransactionInterface.bondSuccess();
+                        break;
+                    case BluetoothDevice.BOND_NONE:
+                        Timber.w("[%s] Bond state changed to NONE", createBondTransactionInterface.getDevice());
+                        // if we are here, we should go ahead and release the lock
+                        // failure
+                        createBondTransactionInterface.bondFailure();
+                        break;
+                    case BluetoothDevice.BOND_BONDING:
+                        Timber.d("[%s] Bond state changed to BONDING", createBondTransactionInterface.getDevice());
+                        // in progress
+                        break;
+                    default:
+                        Timber.w("[%s] Bond state changed to UNKNOWN", createBondTransactionInterface.getDevice());
+                        // could be error, but perhaps not, we don't know
+                        break;
+                }
+            } else {
+                Timber.i("[%s] Received Bond result, but for %s",
+                    createBondTransactionInterface.getDevice(),
+                    extraDevice);
+            }
+        }
+    }
+}

--- a/src/main/java/com/fitbit/bluetooth/fbgatt/receivers/CreateBondTransactionBroadcastReceiver.java
+++ b/src/main/java/com/fitbit/bluetooth/fbgatt/receivers/CreateBondTransactionBroadcastReceiver.java
@@ -11,8 +11,12 @@ import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
 
+import androidx.annotation.VisibleForTesting;
 import timber.log.Timber;
 
+/**
+ * BroadcastReceiver responsible for handling the updates of the BondState of a device.
+ */
 public class CreateBondTransactionBroadcastReceiver extends BroadcastReceiver {
     private final CreateBondTransactionInterface createBondTransactionInterface;
     private final GattUtils gattUtils;
@@ -23,6 +27,7 @@ public class CreateBondTransactionBroadcastReceiver extends BroadcastReceiver {
         this(createBondTransactionInterface, new GattUtils(), new BluetoothDeviceProvider(), new DeviceMatcher());
     }
 
+    @VisibleForTesting
     public CreateBondTransactionBroadcastReceiver(CreateBondTransactionInterface createBondTransactionInterface, GattUtils gattUtils, BluetoothDeviceProviderInterface deviceProvider, DeviceMatcher deviceMatcher) {
         this.createBondTransactionInterface = createBondTransactionInterface;
         this.gattUtils = gattUtils;

--- a/src/main/java/com/fitbit/bluetooth/fbgatt/tx/CreateBondTransaction.java
+++ b/src/main/java/com/fitbit/bluetooth/fbgatt/tx/CreateBondTransaction.java
@@ -13,22 +13,20 @@ import com.fitbit.bluetooth.fbgatt.FitbitGatt;
 import com.fitbit.bluetooth.fbgatt.GattClientTransaction;
 import com.fitbit.bluetooth.fbgatt.GattConnection;
 import com.fitbit.bluetooth.fbgatt.GattState;
-import com.fitbit.bluetooth.fbgatt.GattTransaction;
 import com.fitbit.bluetooth.fbgatt.GattTransactionCallback;
 import com.fitbit.bluetooth.fbgatt.TransactionResult;
+import com.fitbit.bluetooth.fbgatt.receivers.CreateBondTransactionBroadcastReceiver;
 import com.fitbit.bluetooth.fbgatt.util.GattStatus;
-import com.fitbit.bluetooth.fbgatt.util.GattUtils;
 
 import android.bluetooth.BluetoothDevice;
 import android.content.BroadcastReceiver;
 import android.content.Context;
-import android.content.Intent;
 import android.content.IntentFilter;
-import androidx.annotation.Nullable;
-import androidx.annotation.VisibleForTesting;
 
 import java.util.concurrent.TimeUnit;
 
+import androidx.annotation.Nullable;
+import androidx.annotation.VisibleForTesting;
 import timber.log.Timber;
 
 /**
@@ -40,7 +38,7 @@ import timber.log.Timber;
  * <p>
  * Created by iowens on 8/28/18.
  */
-public class CreateBondTransaction extends GattClientTransaction {
+public class CreateBondTransaction extends GattClientTransaction implements CreateBondTransactionInterface {
     /**
      * The transaction name
      */
@@ -56,53 +54,8 @@ public class CreateBondTransaction extends GattClientTransaction {
      * Receiver for {@link BluetoothDevice#ACTION_BOND_STATE_CHANGED}
      */
     @VisibleForTesting(otherwise = VisibleForTesting.PROTECTED)
-    private final BroadcastReceiver receiver = new BroadcastReceiver() {
-        @Override
-        public void onReceive(Context context, Intent intent) {
-            if (BluetoothDevice.ACTION_BOND_STATE_CHANGED.equals(intent.getAction())) {
-                BluetoothDevice extraDevice = intent.getParcelableExtra(BluetoothDevice.EXTRA_DEVICE);
-                /*
-                 * equals handled inside of {@link FitbitBluetoothDevice} for comparison to an
-                 * {@link BluetoothDevice}
-                 */
-                //noinspection EqualsBetweenInconvertibleTypes
-                if (getConnection().getDevice().equals(extraDevice)) {
-                    int oldState = intent.getIntExtra(BluetoothDevice.EXTRA_PREVIOUS_BOND_STATE, BluetoothDevice.BOND_NONE);
-                    int newState = intent.getIntExtra(BluetoothDevice.EXTRA_BOND_STATE, BluetoothDevice.BOND_NONE);
-                    GattUtils util = new GattUtils();
-                    Timber.d("[%s] Bond state changed from %s to %s",
-                            getConnection().getDevice(),
-                            util.getBondStateDescription(oldState),
-                            util.getBondStateDescription(newState));
-                    switch (newState) {
-                        case BluetoothDevice.BOND_BONDED:
-                            Timber.d("[%s] Bond state changed to BONDED",getDevice());
-                            // success
-                            bondSuccess();
-                            break;
-                        case BluetoothDevice.BOND_NONE:
-                            Timber.w("[%s] Bond state changed to NONE",getDevice());
-                            // if we are here, we should go ahead and release the lock
-                            // failure
-                            bondFailure();
-                            break;
-                        case BluetoothDevice.BOND_BONDING:
-                            Timber.d("[%s] Bond state changed to BONDING",getDevice());
-                            // in progress
-                            break;
-                        default:
-                            Timber.w("[%s] Bond state changed to UNKNOWN",getDevice());
-                            // could be error, but perhaps not, we don't know
-                            break;
-                    }
-                } else {
-                    Timber.i("[%s] Received Bond result, but for %s",
-                            getConnection().getDevice(),
-                            extraDevice);
-                }
-            }
-        }
-    };
+    private final BroadcastReceiver receiver = new CreateBondTransactionBroadcastReceiver(this);
+
     /**
      * The transaction builder
      */
@@ -148,7 +101,7 @@ public class CreateBondTransaction extends GattClientTransaction {
     private void createBond(Context context) {
         FitbitBluetoothDevice device = getDevice();
         if (device == null) {
-            Timber.w("[%s] Couldn't create the bond because device was null", device);
+            Timber.w("Couldn't create the bond because device was null");
             bondFailure();
         } else {
             createBond(context, device);
@@ -169,14 +122,15 @@ public class CreateBondTransaction extends GattClientTransaction {
         device.getBtDevice().createBond();
     }
 
+    @Override
     @VisibleForTesting
-    void bondSuccess() {
+    public void bondSuccess() {
         Timber.v("[%s] The bond attempt succeeded", getDevice());
         getConnection().setState(GattState.CREATE_BOND_SUCCESS);
         builder.transactionName(NAME)
-                .gattState(getConnection().getGattState())
-                .responseStatus(GattStatus.GATT_SUCCESS.ordinal())
-                .resultStatus(TransactionResult.TransactionResultStatus.SUCCESS);
+            .gattState(getConnection().getGattState())
+            .responseStatus(GattStatus.GATT_SUCCESS.ordinal())
+            .resultStatus(TransactionResult.TransactionResultStatus.SUCCESS);
         if (callback != null) {
             callCallbackWithTransactionResultAndRelease(callback, builder.build());
         }
@@ -190,13 +144,14 @@ public class CreateBondTransaction extends GattClientTransaction {
 
     }
 
-    private void bondFailure() {
+    @Override
+    public void bondFailure() {
         Timber.v("[%s] The bond attempt failed", getDevice());
         getConnection().setState(GattState.CREATE_BOND_FAILURE);
         builder.transactionName(NAME)
-                .gattState(getConnection().getGattState())
-                .responseStatus(GattStatus.GATT_INTERNAL_ERROR.ordinal())
-                .resultStatus(TransactionResult.TransactionResultStatus.FAILURE);
+            .gattState(getConnection().getGattState())
+            .responseStatus(GattStatus.GATT_INTERNAL_ERROR.ordinal())
+            .resultStatus(TransactionResult.TransactionResultStatus.FAILURE);
         if (callback != null) {
             callCallbackWithTransactionResultAndRelease(callback, builder.build());
         }

--- a/src/main/java/com/fitbit/bluetooth/fbgatt/tx/CreateBondTransaction.java
+++ b/src/main/java/com/fitbit/bluetooth/fbgatt/tx/CreateBondTransaction.java
@@ -84,9 +84,7 @@ public class CreateBondTransaction extends GattClientTransaction {
                             Timber.w("[%s] Bond state changed to NONE",getDevice());
                             // if we are here, we should go ahead and release the lock
                             // failure
-                            synchronized (NAME) {
-                                NAME.notify();
-                            }
+                            bondFailure();
                             break;
                         case BluetoothDevice.BOND_BONDING:
                             Timber.d("[%s] Bond state changed to BONDING",getDevice());

--- a/src/main/java/com/fitbit/bluetooth/fbgatt/tx/CreateBondTransactionInterface.java
+++ b/src/main/java/com/fitbit/bluetooth/fbgatt/tx/CreateBondTransactionInterface.java
@@ -2,6 +2,10 @@ package com.fitbit.bluetooth.fbgatt.tx;
 
 import com.fitbit.bluetooth.fbgatt.FitbitBluetoothDevice;
 
+/**
+ * Interface to be used as a bridge between the [CreateBondTransactionReceiver
+ * and the [CreateBondTransaction].
+ */
 public interface CreateBondTransactionInterface {
     FitbitBluetoothDevice getDevice();
 

--- a/src/main/java/com/fitbit/bluetooth/fbgatt/tx/CreateBondTransactionInterface.java
+++ b/src/main/java/com/fitbit/bluetooth/fbgatt/tx/CreateBondTransactionInterface.java
@@ -1,0 +1,11 @@
+package com.fitbit.bluetooth.fbgatt.tx;
+
+import com.fitbit.bluetooth.fbgatt.FitbitBluetoothDevice;
+
+public interface CreateBondTransactionInterface {
+    FitbitBluetoothDevice getDevice();
+
+    void bondSuccess();
+
+    void bondFailure();
+}

--- a/src/main/java/com/fitbit/bluetooth/fbgatt/util/BluetoothDeviceProvider.java
+++ b/src/main/java/com/fitbit/bluetooth/fbgatt/util/BluetoothDeviceProvider.java
@@ -1,0 +1,14 @@
+package com.fitbit.bluetooth.fbgatt.util;
+
+import android.bluetooth.BluetoothDevice;
+import android.content.Intent;
+
+import javax.annotation.Nullable;
+
+public class BluetoothDeviceProvider implements BluetoothDeviceProviderInterface{
+    @Nullable
+    @Override
+    public BluetoothDevice getFromIntent(@Nullable Intent intent) {
+        return intent != null ? (BluetoothDevice) intent.getParcelableExtra(BluetoothDevice.EXTRA_DEVICE): null;
+    }
+}

--- a/src/main/java/com/fitbit/bluetooth/fbgatt/util/BluetoothDeviceProvider.java
+++ b/src/main/java/com/fitbit/bluetooth/fbgatt/util/BluetoothDeviceProvider.java
@@ -5,6 +5,9 @@ import android.content.Intent;
 
 import javax.annotation.Nullable;
 
+/**
+ * Main implementation of the [BluetoothDeviceProviderInterface].
+ */
 public class BluetoothDeviceProvider implements BluetoothDeviceProviderInterface{
     @Nullable
     @Override

--- a/src/main/java/com/fitbit/bluetooth/fbgatt/util/BluetoothDeviceProviderInterface.java
+++ b/src/main/java/com/fitbit/bluetooth/fbgatt/util/BluetoothDeviceProviderInterface.java
@@ -1,0 +1,11 @@
+package com.fitbit.bluetooth.fbgatt.util;
+
+import android.bluetooth.BluetoothDevice;
+import android.content.Intent;
+
+import javax.annotation.Nullable;
+
+public interface BluetoothDeviceProviderInterface {
+    @Nullable
+    BluetoothDevice getFromIntent(@Nullable Intent intent);
+}

--- a/src/main/java/com/fitbit/bluetooth/fbgatt/util/BluetoothDeviceProviderInterface.java
+++ b/src/main/java/com/fitbit/bluetooth/fbgatt/util/BluetoothDeviceProviderInterface.java
@@ -5,7 +5,18 @@ import android.content.Intent;
 
 import javax.annotation.Nullable;
 
+/**
+ * Interface to be used for retrieving a [BluetoothDevice] from the
+ * [Intent]'s extras using the [BluetoothDevice.EXTRA_DEVICE].
+ */
 public interface BluetoothDeviceProviderInterface {
+    /**
+     * Returns the parsed [BluetoothDevice] if it can be parsed.
+     *
+     * @param intent - the [Intent] from which to retrieve the [BluetoothDevice]
+     * @return the [BluetoothDevice] or null if it cannot be parsed or if the extras
+     * do not hold such information.
+     */
     @Nullable
     BluetoothDevice getFromIntent(@Nullable Intent intent);
 }

--- a/src/main/java/com/fitbit/bluetooth/fbgatt/util/DeviceMatcher.java
+++ b/src/main/java/com/fitbit/bluetooth/fbgatt/util/DeviceMatcher.java
@@ -1,0 +1,12 @@
+package com.fitbit.bluetooth.fbgatt.util;
+
+import com.fitbit.bluetooth.fbgatt.FitbitBluetoothDevice;
+
+import android.bluetooth.BluetoothDevice;
+
+public class DeviceMatcher implements DeviceMatcherInterface {
+    @Override
+    public boolean matchDevices(FitbitBluetoothDevice fitbitBtDevice, BluetoothDevice btDevice) {
+        return fitbitBtDevice != null && fitbitBtDevice.equals(btDevice);
+    }
+}

--- a/src/main/java/com/fitbit/bluetooth/fbgatt/util/DeviceMatcher.java
+++ b/src/main/java/com/fitbit/bluetooth/fbgatt/util/DeviceMatcher.java
@@ -4,6 +4,9 @@ import com.fitbit.bluetooth.fbgatt.FitbitBluetoothDevice;
 
 import android.bluetooth.BluetoothDevice;
 
+/**
+ * Main implementation of the [DeviceMatcherInterface].
+ */
 public class DeviceMatcher implements DeviceMatcherInterface {
     @Override
     public boolean matchDevices(FitbitBluetoothDevice fitbitBtDevice, BluetoothDevice btDevice) {

--- a/src/main/java/com/fitbit/bluetooth/fbgatt/util/DeviceMatcherInterface.java
+++ b/src/main/java/com/fitbit/bluetooth/fbgatt/util/DeviceMatcherInterface.java
@@ -4,6 +4,22 @@ import com.fitbit.bluetooth.fbgatt.FitbitBluetoothDevice;
 
 import android.bluetooth.BluetoothDevice;
 
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+/**
+ * Util interface to be used for matching a [FitbitBluetoothDevice] to
+ * a [BluetoothDevice].
+ */
 public interface DeviceMatcherInterface {
-    boolean matchDevices(FitbitBluetoothDevice fitbitBtDevice, BluetoothDevice btDevice);
+    /**
+     * Method checking if the [FitbitBluetoothDevice] and the [BluetoothDevice]
+     * represent the same object.
+     *
+     * @param fitbitBtDevice - to be used for matching
+     * @param btDevice - to be used for matching
+     *
+     * @return true if they represent the same object, false otherwise.
+     */
+    boolean matchDevices(@Nonnull FitbitBluetoothDevice fitbitBtDevice, @Nullable BluetoothDevice btDevice);
 }

--- a/src/main/java/com/fitbit/bluetooth/fbgatt/util/DeviceMatcherInterface.java
+++ b/src/main/java/com/fitbit/bluetooth/fbgatt/util/DeviceMatcherInterface.java
@@ -1,0 +1,9 @@
+package com.fitbit.bluetooth.fbgatt.util;
+
+import com.fitbit.bluetooth.fbgatt.FitbitBluetoothDevice;
+
+import android.bluetooth.BluetoothDevice;
+
+public interface DeviceMatcherInterface {
+    boolean matchDevices(FitbitBluetoothDevice fitbitBtDevice, BluetoothDevice btDevice);
+}

--- a/src/test/java/com/fitbit/bluetooth/fbgatt/receivers/CreateBondTransactionBroadcastReceiverTest.java
+++ b/src/test/java/com/fitbit/bluetooth/fbgatt/receivers/CreateBondTransactionBroadcastReceiverTest.java
@@ -1,0 +1,77 @@
+package com.fitbit.bluetooth.fbgatt.receivers;
+
+import com.fitbit.bluetooth.fbgatt.FitbitBluetoothDevice;
+import com.fitbit.bluetooth.fbgatt.tx.CreateBondTransactionInterface;
+import com.fitbit.bluetooth.fbgatt.util.BluetoothDeviceProviderInterface;
+import com.fitbit.bluetooth.fbgatt.util.DeviceMatcher;
+import com.fitbit.bluetooth.fbgatt.util.GattUtils;
+
+import android.bluetooth.BluetoothDevice;
+import android.content.Context;
+import android.content.Intent;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class CreateBondTransactionBroadcastReceiverTest {
+    private final CreateBondTransactionInterface mockBondTransactionInterface = mock(CreateBondTransactionInterface.class);
+    private final GattUtils mockGattUtils = mock(GattUtils.class);
+    private final BluetoothDeviceProviderInterface mockDeviceProvider = mock(BluetoothDeviceProviderInterface.class);
+    private final DeviceMatcher mockDeviceMatcher = mock(DeviceMatcher.class);
+
+    private final Context mockContext = mock(Context.class);
+    private final FitbitBluetoothDevice mockDevice = mock(FitbitBluetoothDevice.class);
+    private final BluetoothDevice mockBtDevice = mock(BluetoothDevice.class);
+
+    private final Intent mockIntent = mock(Intent.class);
+
+    private final CreateBondTransactionBroadcastReceiver sut = new CreateBondTransactionBroadcastReceiver(mockBondTransactionInterface, mockGattUtils, mockDeviceProvider, mockDeviceMatcher);
+
+    @Before
+    public void before() {
+        doReturn(mockDevice).when(mockBondTransactionInterface).getDevice();
+        doReturn(mockBtDevice).when(mockDeviceProvider).getFromIntent(any(Intent.class));
+        doReturn(true).when(mockDeviceMatcher).matchDevices(mockDevice, mockBtDevice);
+        when(mockIntent.getAction()).thenReturn(BluetoothDevice.ACTION_BOND_STATE_CHANGED);
+        when(mockIntent.getIntExtra(eq(BluetoothDevice.EXTRA_PREVIOUS_BOND_STATE), anyInt())).thenReturn(BluetoothDevice.BOND_NONE);
+    }
+
+    @Test
+    public void shouldNotifyCallerOfSuccess() {
+        when(mockIntent.getIntExtra(eq(BluetoothDevice.EXTRA_BOND_STATE), anyInt())).thenReturn(BluetoothDevice.BOND_BONDED);
+
+        sut.onReceive(mockContext, mockIntent);
+
+        verify(mockBondTransactionInterface).bondSuccess();
+        verify(mockBondTransactionInterface, never()).bondFailure();
+    }
+
+    @Test
+    public void shouldNotifyCallerOfFailures() {
+        when(mockIntent.getIntExtra(eq(BluetoothDevice.EXTRA_BOND_STATE), anyInt())).thenReturn(BluetoothDevice.BOND_NONE);
+
+        sut.onReceive(mockContext, mockIntent);
+
+        verify(mockBondTransactionInterface, never()).bondSuccess();
+        verify(mockBondTransactionInterface).bondFailure();
+    }
+
+    @Test
+    public void shouldNotNotifyCallerOfBondingState() {
+        when(mockIntent.getIntExtra(eq(BluetoothDevice.EXTRA_BOND_STATE), anyInt())).thenReturn(BluetoothDevice.BOND_BONDING);
+
+        sut.onReceive(mockContext, mockIntent);
+
+        verify(mockBondTransactionInterface, never()).bondSuccess();
+        verify(mockBondTransactionInterface, never()).bondFailure();
+    }
+}

--- a/src/test/java/com/fitbit/bluetooth/fbgatt/receivers/CreateBondTransactionBroadcastReceiverTest.java
+++ b/src/test/java/com/fitbit/bluetooth/fbgatt/receivers/CreateBondTransactionBroadcastReceiverTest.java
@@ -57,6 +57,7 @@ public class CreateBondTransactionBroadcastReceiverTest {
 
     @Test
     public void shouldNotifyCallerOfFailures() {
+        when(mockIntent.getIntExtra(eq(BluetoothDevice.EXTRA_PREVIOUS_BOND_STATE), anyInt())).thenReturn(BluetoothDevice.BOND_BONDING);
         when(mockIntent.getIntExtra(eq(BluetoothDevice.EXTRA_BOND_STATE), anyInt())).thenReturn(BluetoothDevice.BOND_NONE);
 
         sut.onReceive(mockContext, mockIntent);
@@ -68,6 +69,21 @@ public class CreateBondTransactionBroadcastReceiverTest {
     @Test
     public void shouldNotNotifyCallerOfBondingState() {
         when(mockIntent.getIntExtra(eq(BluetoothDevice.EXTRA_BOND_STATE), anyInt())).thenReturn(BluetoothDevice.BOND_BONDING);
+
+        sut.onReceive(mockContext, mockIntent);
+
+        verify(mockBondTransactionInterface, never()).bondSuccess();
+        verify(mockBondTransactionInterface, never()).bondFailure();
+    }
+
+    /**
+     * Do not notify changes for [BluetoothDevice.BOND_NONE] when
+     * last state was also [BluetoothDevice.BOND_NONE].
+     */
+    @Test
+    public void shouldNotNotifyFailureForEdgeCase() {
+        when(mockIntent.getIntExtra(eq(BluetoothDevice.EXTRA_PREVIOUS_BOND_STATE), anyInt())).thenReturn(BluetoothDevice.BOND_NONE);
+        when(mockIntent.getIntExtra(eq(BluetoothDevice.EXTRA_BOND_STATE), anyInt())).thenReturn(BluetoothDevice.BOND_NONE);
 
         sut.onReceive(mockContext, mockIntent);
 


### PR DESCRIPTION
Fixes # 
Moving to bond state NONE should result in completion by failure

### description
When a bond transaction changes state to NONE, the caller does not get notified of any errors/failures.

### changes
- Notify the caller of a failure and complete the bond transaction.

### how tested
Unit tests:

Created a unit test to confirm that the caller gets notified that the CreateBondTransaction successfully completes when state changes to BOND_BONDED and BOND_NONE (failure).
Created a unit test to confirm that the caller does not get notified when the state changes to BOND_BONDING.
Created unit test to confirm that the caller does not get notified of errors if the newState and oldState have the same value.