### PR TITLE
Fix lint issues in previous PR

### DIFF
--- a/src/main/java/com/fitbit/bluetooth/fbgatt/util/BluetoothDeviceProvider.java
+++ b/src/main/java/com/fitbit/bluetooth/fbgatt/util/BluetoothDeviceProvider.java
@@ -3,7 +3,7 @@ package com.fitbit.bluetooth.fbgatt.util;
 import android.bluetooth.BluetoothDevice;
 import android.content.Intent;
 
-import javax.annotation.Nullable;
+import androidx.annotation.Nullable;
 
 /**
  * Main implementation of the [BluetoothDeviceProviderInterface].

--- a/src/main/java/com/fitbit/bluetooth/fbgatt/util/BluetoothDeviceProviderInterface.java
+++ b/src/main/java/com/fitbit/bluetooth/fbgatt/util/BluetoothDeviceProviderInterface.java
@@ -3,7 +3,7 @@ package com.fitbit.bluetooth.fbgatt.util;
 import android.bluetooth.BluetoothDevice;
 import android.content.Intent;
 
-import javax.annotation.Nullable;
+import androidx.annotation.Nullable;
 
 /**
  * Interface to be used for retrieving a [BluetoothDevice] from the

--- a/src/main/java/com/fitbit/bluetooth/fbgatt/util/DeviceMatcher.java
+++ b/src/main/java/com/fitbit/bluetooth/fbgatt/util/DeviceMatcher.java
@@ -3,13 +3,15 @@ package com.fitbit.bluetooth.fbgatt.util;
 import com.fitbit.bluetooth.fbgatt.FitbitBluetoothDevice;
 
 import android.bluetooth.BluetoothDevice;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 /**
  * Main implementation of the [DeviceMatcherInterface].
  */
 public class DeviceMatcher implements DeviceMatcherInterface {
     @Override
-    public boolean matchDevices(FitbitBluetoothDevice fitbitBtDevice, BluetoothDevice btDevice) {
+    public boolean matchDevices(@NonNull FitbitBluetoothDevice fitbitBtDevice, @Nullable BluetoothDevice btDevice) {
         return fitbitBtDevice != null && fitbitBtDevice.equals(btDevice);
     }
 }

--- a/src/main/java/com/fitbit/bluetooth/fbgatt/util/DeviceMatcherInterface.java
+++ b/src/main/java/com/fitbit/bluetooth/fbgatt/util/DeviceMatcherInterface.java
@@ -4,8 +4,8 @@ import com.fitbit.bluetooth.fbgatt.FitbitBluetoothDevice;
 
 import android.bluetooth.BluetoothDevice;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 /**
  * Util interface to be used for matching a [FitbitBluetoothDevice] to
@@ -21,5 +21,5 @@ public interface DeviceMatcherInterface {
      *
      * @return true if they represent the same object, false otherwise.
      */
-    boolean matchDevices(@Nonnull FitbitBluetoothDevice fitbitBtDevice, @Nullable BluetoothDevice btDevice);
+    boolean matchDevices(@NonNull FitbitBluetoothDevice fitbitBtDevice, @Nullable BluetoothDevice btDevice);
 }


### PR DESCRIPTION
Fixes # Lint failure in release build

### description
The lintRelease gradle task is failing on develop because it can't find the javax annotations. 

### changes
Switch to androidx annotations instead of javax

### how tested
Ran lintRelease locally and it passes
