### PR TITLE
For publish maven run just the release aar

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,9 +37,7 @@ if (releaseTag != null && !releaseTag.isEmpty()) {
     println("Releasing with version " + version);
 }
 
-def isJitPack =  System.getenv('JITPACK') ? System.getenv('JITPACK').toBoolean() : false
 def artifactPath = "$buildDir/outputs/aar"
-def libPrefix = project.name
 
 
 android {
@@ -65,11 +63,6 @@ android {
             consumerProguardFiles 'proguard-rules.pro'
         }
         debug {
-            testCoverageEnabled false
-        }
-        library {
-            debuggable true
-            minifyEnabled false
             testCoverageEnabled false
         }
     }
@@ -131,15 +124,13 @@ android.libraryVariants.all { variant ->
 
 publishing {
     publications {
-        android.libraryVariants.all { variant ->
-            "${variant.name.capitalize()}Aar"(MavenPublication) {
-                from components.findByName("android${variant.name.capitalize()}")
-                groupId group
-                artifactId 'bitgatt'
-                version "$version-${variant.name}"
-                artifact("$artifactPath/${variant.name}.aar")  {
-                    builtBy tasks.getByName("build")
-                }
+        release (MavenPublication) {
+            from components.findByName("androidRelease")
+            groupId  group
+            artifactId 'bitgatt'
+            version "$version-release"
+            artifact("$artifactPath/release.aar")  {
+                builtBy tasks.getByName("build")
             }
         }
     }


### PR DESCRIPTION
Jitpack seems to pick differently the aar distributed based on TAG vs
commit hash

This ensures that we will have only release aar for jitpack to use


Tested with a fork building the aar on jitpack and ensure debug is disabled.