### PR TITLE
remove synchronized on isInitialized()

### DIFF
--- a/src/main/java/com/fitbit/bluetooth/fbgatt/FitbitGatt.java
+++ b/src/main/java/com/fitbit/bluetooth/fbgatt/FitbitGatt.java
@@ -1022,7 +1022,7 @@ public class FitbitGatt implements PeripheralScanner.TrackerScannerListener, Blu
     }
 
     @RestrictTo(RestrictTo.Scope.LIBRARY)
-    synchronized boolean isInitialized() {
+    boolean isInitialized() {
         return isInitialized.get();
     }
 


### PR DESCRIPTION
remove synchronized keyword since we don't need to guard an AtomicBoolean here, and the lock can be held over the course of a possibly long listener dispatch.