### PR TITLE
Init BluetoothGatt for Connected devices

### DIFF
--- a/src/main/java/com/fitbit/bluetooth/fbgatt/GattConnection.java
+++ b/src/main/java/com/fitbit/bluetooth/fbgatt/GattConnection.java
@@ -333,6 +333,24 @@ public class GattConnection implements Closeable {
         }
     }
 
+    /**
+     * This method is called only for devices that are already connected on Gatt Profile
+     * {@link android.bluetooth.BluetoothManager#getConnectedDevices(int)}
+     * <p>
+     * Will perform a gatt connect on the device, to initialise [BluetoothGatt]
+     * for this connection and set the state to [GattState.CONNECTED]
+     * because no connection change callback will happen
+     */
+    void initGattForConnectedDevice() {
+        Timber.v("[%s] already connected, init BluetoothGatt ", device);
+        if (isConnected()) {
+            return;
+        }
+        if (ifGattHasNeverBeenInstantiatedConnect(device)) {
+            setState(GattState.CONNECTED);
+        }
+    }
+
     private boolean connectionInstanceAlreadyExists(FitbitBluetoothDevice device) {
         GattConnection cachedConnection = FitbitGatt.getInstance().getConnectionMap().get(device);
         if (cachedConnection != null && !cachedConnection.equals(this)) {


### PR DESCRIPTION
Fixes #
GattConnection for Connected devices
### description
When a connected device is added, we need to also initialise BluetoothGatt, not just connection state

### changes
- When adding connected devices, setup BluetoothGatt and set Connection state to Connected
- Switch order between connected and bonded devices

### how tested
- Unit tests
- Using Guci app -> performed ConnectTest
- Loki
