### PR TITLE
Remove location permission requirement for PI broadcast receiver and fix PendingIntent flag bug

### DIFF
--- a/src/main/AndroidManifest.xml
+++ b/src/main/AndroidManifest.xml
@@ -6,34 +6,31 @@
   ~ file, You can obtain one at https://mozilla.org/MPL/2.0/.
   -->
 
-<manifest package="com.fitbit.bluetooth.fbgatt"
-          xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    package="com.fitbit.bluetooth.fbgatt">
 
-    <uses-sdk android:minSdkVersion="21"
-        android:targetSdkVersion="29"
-        />
+  <uses-permission android:name="android.permission.BLUETOOTH" />
+  <uses-permission android:name="android.permission.BLUETOOTH_ADMIN" />
+  <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
 
-    <uses-permission android:name="android.permission.BLUETOOTH"/>
-    <uses-permission android:name="android.permission.BLUETOOTH_ADMIN"/>
-    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"/>
-    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION"/>
-    <!-- Be sure to add this into your app's manifest or utilize the manifest merger to make sure
-         that you can use the pending intent scanner, otherwise results will not be delivered
-         to your application -->
-    <application>
-        <receiver android:exported="true" android:name=".HandleIntentBasedScanResult"
-            android:permission="android.permission.ACCESS_COURSE_LOCATION">
-            <intent-filter>
-                <!-- if you change this make sure to also change it in {@link PeripheralScanner} -->
-                <action android:name="com.fitbit.bluetooth.fbgatt.ScannedDevice" />
-            </intent-filter>
-        </receiver>
-        <receiver android:name=".LowEnergyAclListener" android:exported="true"
-                  android:permission="android.permission.ACCESS_FINE_LOCATION">
-            <intent-filter>
-                <action android:name="BluetoothDevice.ACTION_FOUND" />
-            </intent-filter>
-        </receiver>
-    </application>
+  <!-- Be sure to add this into your app's manifest or utilize the manifest merger to make sure
+       that you can use the pending intent scanner, otherwise results will not be delivered
+       to your application -->
+  <application>
+    <receiver
+        android:name=".HandleIntentBasedScanResult"
+        android:exported="true"
+        tools:ignore="ExportedReceiver">
+      <intent-filter>
+        <!-- if you change this make sure to also change it in {@link PeripheralScanner} -->
+        <action android:name="com.fitbit.bluetooth.fbgatt.ScannedDevice" />
+      </intent-filter>
+    </receiver>
+    <receiver
+        android:name=".LowEnergyAclListener"
+        android:exported="true"
+        tools:ignore="ExportedReceiver" />
+  </application>
 
 </manifest>

--- a/src/main/java/com/fitbit/bluetooth/fbgatt/LowEnergyAclListener.java
+++ b/src/main/java/com/fitbit/bluetooth/fbgatt/LowEnergyAclListener.java
@@ -40,7 +40,6 @@ public class LowEnergyAclListener extends BroadcastReceiver {
     static AtomicInteger timesRegistered = new AtomicInteger(0);
 
     private IntentFilter[] filters = {
-        new IntentFilter(BluetoothDevice.ACTION_FOUND),
         new IntentFilter(BluetoothDevice.ACTION_ACL_DISCONNECTED),
         new IntentFilter(BluetoothDevice.ACTION_ACL_CONNECTED),
         new IntentFilter(BluetoothDevice.ACTION_ACL_DISCONNECT_REQUESTED)
@@ -77,11 +76,6 @@ public class LowEnergyAclListener extends BroadcastReceiver {
             return;
         }
         FitbitBluetoothDevice fbDevice = new FitbitBluetoothDevice(device);
-        if (BluetoothDevice.ACTION_FOUND.equals(action)) {
-            Timber.i("%s Device found", fbDevice.getName());
-            // device was discovered in scan but we don't necessarily want to just add it unless
-            // it's connected to the phone
-        }
         if (BluetoothDevice.ACTION_ACL_CONNECTED.equals(action)) {
             Timber.i("%s Device is now connected", fbDevice.getName());
             // device was connected to the phone, does not mean device is connected to the

--- a/src/main/java/com/fitbit/bluetooth/fbgatt/PeripheralScanner.java
+++ b/src/main/java/com/fitbit/bluetooth/fbgatt/PeripheralScanner.java
@@ -38,6 +38,7 @@ import static android.bluetooth.le.ScanCallback.SCAN_FAILED_APPLICATION_REGISTRA
 import static android.bluetooth.le.ScanCallback.SCAN_FAILED_FEATURE_UNSUPPORTED;
 import static android.bluetooth.le.ScanCallback.SCAN_FAILED_INTERNAL_ERROR;
 import static android.os.Build.VERSION_CODES.M;
+import static android.os.Build.VERSION_CODES.S;
 import static android.os.Build.VERSION_CODES.O;
 import static com.fitbit.bluetooth.fbgatt.FitbitGatt.atLeastSDK;
 
@@ -631,8 +632,13 @@ class PeripheralScanner {
         Intent broadcastIntent = new Intent(context, HandleIntentBasedScanResult.class);
         broadcastIntent.setAction(SCANNED_DEVICE_ACTION);
         broadcastIntent.setClass(context, HandleIntentBasedScanResult.class);
-        return PendingIntent.getBroadcast(context,
-                BACKGROUND_SCAN_REQUEST_CODE, broadcastIntent, PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE);
+
+        int flags = PendingIntent.FLAG_UPDATE_CURRENT;
+        if(atLeastSDK(S)) {
+            flags |= PendingIntent.FLAG_MUTABLE;
+        }
+
+        return PendingIntent.getBroadcast(context, BACKGROUND_SCAN_REQUEST_CODE, broadcastIntent, flags);
     }
 
     /**


### PR DESCRIPTION
This change contains following changes/fixes
1. To support Android S, FLAG_IMMUTABLE flag was added. But to receive result for PI scanner you need to pass FLAG_MUTABLE flag
2. If client is targeting Android S+ and relying on Nearby permissions PendingIntent broadcast receiver need to remove the location permission requirement on manifest receiver declaration
3. Same permission removal for for ACL connect receiver and removing ACTION_FOUND filter since it was a no-op


Testing: Verified from Fitbit app on Android 12 and 9