### PR TITLE
GATT service subscription failure dur to incorrect state and anothe NPE fix

### DIFF
--- a/src/debug/java/com/fitbit/bluetooth/fbgatt/tx/mocks/AddGattServerServiceMockTransaction.java
+++ b/src/debug/java/com/fitbit/bluetooth/fbgatt/tx/mocks/AddGattServerServiceMockTransaction.java
@@ -56,8 +56,8 @@ public class AddGattServerServiceMockTransaction extends AddGattServerServiceTra
                         .gattState(getGattServer().getGattState())
                         .resultStatus(TransactionResult.TransactionResultStatus.SUCCESS);
                 callCallbackWithTransactionResultAndRelease(callback, transactionResultBuilder.build());
-                getGattServer().setState(GattState.IDLE);
             }
+            getGattServer().resetState();
         }, REASONABLE_AMOUNT_OF_TIME_FOR_ADDING_SERVICE);
     }
 

--- a/src/debug/java/com/fitbit/bluetooth/fbgatt/tx/mocks/GattServerConnectMockTransaction.java
+++ b/src/debug/java/com/fitbit/bluetooth/fbgatt/tx/mocks/GattServerConnectMockTransaction.java
@@ -46,14 +46,13 @@ public class GattServerConnectMockTransaction extends GattServerConnectTransacti
                 getGattServer().setState(GattState.FAILURE_CONNECTING);
                 builder.resultStatus(TransactionResult.TransactionResultStatus.FAILURE)
                         .gattState(getGattServer().getGattState());
-                callCallbackWithTransactionResultAndRelease(callback, builder.build());
             } else {
                 getGattServer().setState(GattState.CONNECTED);
                 builder.resultStatus(TransactionResult.TransactionResultStatus.SUCCESS)
                         .gattState(getGattServer().getGattState());
-                callCallbackWithTransactionResultAndRelease(callback, builder.build());
-                getGattServer().setState(GattState.IDLE);
             }
+            callCallbackWithTransactionResultAndRelease(callback, builder.build());
+            getGattServer().resetState();
         }, REASONABLE_AMOUNT_OF_TIME_FOR_CONNECT);
     }
 }

--- a/src/debug/java/com/fitbit/bluetooth/fbgatt/tx/mocks/NotifyGattServerCharacteristicMockTransaction.java
+++ b/src/debug/java/com/fitbit/bluetooth/fbgatt/tx/mocks/NotifyGattServerCharacteristicMockTransaction.java
@@ -62,7 +62,7 @@ public class NotifyGattServerCharacteristicMockTransaction extends NotifyGattSer
                     }
                     getGattServer().setState(GattState.NOTIFY_CHARACTERISTIC_FAILURE);
                     builder.resultStatus(TransactionResult.TransactionResultStatus.FAILURE);
-                    getGattServer().setState(GattState.IDLE);
+                    getGattServer().resetState();
                     Strategy strategy = strategyProvider.
                             getStrategyForPhoneAndGattConnection(null, null,
                                     Situation.TRACKER_WENT_AWAY_DURING_GATT_OPERATION);

--- a/src/debug/java/com/fitbit/bluetooth/fbgatt/tx/mocks/SendGattServerResponseMockTransaction.java
+++ b/src/debug/java/com/fitbit/bluetooth/fbgatt/tx/mocks/SendGattServerResponseMockTransaction.java
@@ -43,21 +43,16 @@ public class SendGattServerResponseMockTransaction extends SendGattServerRespons
             if (shouldFail) {
                 getGattServer().setState(GattState.SEND_SERVER_RESPONSE_FAILURE);
                 builder.resultStatus(TransactionResult.TransactionResultStatus.FAILURE);
-                builder.gattState(getGattServer().getGattState()).
-                        data(value).
-                        requestId(requestId).
-                        offset(offset);
-                callCallbackWithTransactionResultAndRelease(callback, builder.build());
             } else {
                 getGattServer().setState(GattState.SEND_SERVER_RESPONSE_SUCCESS);
                 builder.resultStatus(TransactionResult.TransactionResultStatus.SUCCESS);
-                builder.gattState(getGattServer().getGattState()).
-                        data(value).
-                        requestId(requestId).
-                        offset(offset);
-                callCallbackWithTransactionResultAndRelease(callback, builder.build());
-                getGattServer().setState(GattState.IDLE);
             }
+            builder.gattState(getGattServer().getGattState()).
+                    data(value).
+                    requestId(requestId).
+                    offset(offset);
+            callCallbackWithTransactionResultAndRelease(callback, builder.build());
+            getGattServer().resetState();
         }, REASONABLE_TIME_FOR_SEND_RESPONSE);
     }
 }

--- a/src/main/java/com/fitbit/bluetooth/fbgatt/FitbitGatt.java
+++ b/src/main/java/com/fitbit/bluetooth/fbgatt/FitbitGatt.java
@@ -1470,10 +1470,10 @@ public class FitbitGatt implements PeripheralScanner.TrackerScannerListener, Blu
                         if (serverConnection != null) {
                             // We have a new server instance we need to replace it in the GattServerConnection
                             serverConnection.close();
-                            serverConnection.setState(GattState.IDLE);
+                            serverConnection.resetState();
                         }
                         setGattServerConnection(new GattServerConnection(gattServer, context.getMainLooper()));
-                        serverConnection.setState(GattState.IDLE);
+                        serverConnection.resetState();
                         callback.onGattServerStatus(true);
                         isGattServerStarting.set(false);
                         Timber.tag("FitbitGattServer").v("Gatt server successfully opened");
@@ -1663,6 +1663,7 @@ public class FitbitGatt implements PeripheralScanner.TrackerScannerListener, Blu
         }
     }
 
+    @Nullable
     public GattServerConnection getServer() {
         return serverConnection;
     }

--- a/src/main/java/com/fitbit/bluetooth/fbgatt/GattConnection.java
+++ b/src/main/java/com/fitbit/bluetooth/fbgatt/GattConnection.java
@@ -53,12 +53,14 @@ public class GattConnection implements Closeable {
     private @NonNull Handler mainHandler;
     private final FitbitGatt fitbitGatt = FitbitGatt.getInstance();
 
+    private static GattState DEFAULT_STATE = GattState.DISCONNECTED;
+
     public GattConnection(FitbitBluetoothDevice device, Looper mainLooper) {
         this.device = device;
         this.guard = new GattStateTransitionValidator<GattClientTransaction>();
         this.mockServices = new ArrayList<>(1);
         this.clientQueue = new TransactionQueueController(this);
-        this.state = GattState.DISCONNECTED;
+        this.state = DEFAULT_STATE;
         this.disconnectedTTL = new AtomicLong(FitbitGatt.MAX_TTL);
         this.mainHandler = new Handler(mainLooper);
     }
@@ -216,8 +218,11 @@ public class GattConnection implements Closeable {
         return guard.checkTransaction(getGattState(), tx);
     }
 
-    void resetStates() {
-        this.setState(GattState.DISCONNECTED);
+    /**
+     * Reset to default connection state
+     */
+    public void resetState() {
+        this.setState(DEFAULT_STATE);
     }
 
     @VisibleForTesting

--- a/src/main/java/com/fitbit/bluetooth/fbgatt/GattServerCallback.java
+++ b/src/main/java/com/fitbit/bluetooth/fbgatt/GattServerCallback.java
@@ -93,6 +93,8 @@ class GattServerCallback extends BluetoothGattServerCallback {
         if (fitbitGatt.isSlowLoggingEnabled()) {
             Timber.v("[%s] onConnectionStateChange: Gatt Response Status %s", getDeviceMacFromDevice(device), GattStatus.getStatusForCode(status));
             Timber.d("[%s][Threading] Originally called on thread : %s", getDeviceMacFromDevice(device), Thread.currentThread().getName());
+        } else {
+            Timber.v("onConnectionStateChange: Gatt Response Status %s", GattStatus.getStatusForCode(status));
         }
         ArrayList<GattServerListener> copy = new ArrayList<>(listeners.size());
         copy.addAll(listeners);

--- a/src/main/java/com/fitbit/bluetooth/fbgatt/GattServerConnection.java
+++ b/src/main/java/com/fitbit/bluetooth/fbgatt/GattServerConnection.java
@@ -14,14 +14,14 @@ import android.bluetooth.BluetoothProfile;
 import android.os.Build;
 import android.os.Handler;
 import android.os.Looper;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.annotation.VisibleForTesting;
 import java.io.Closeable;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicLong;
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
-import androidx.annotation.VisibleForTesting;
 import timber.log.Timber;
 
 /**
@@ -42,11 +42,13 @@ public class GattServerConnection implements Closeable {
     private Handler mainHandler;
     private boolean mockMode;
 
+    private static GattState DEFAULT_STATE = GattState.IDLE;
+
     protected GattServerConnection(@Nullable BluetoothGattServer server, Looper looper) {
         this.server = server;
         this.serverQueue = new TransactionQueueController();
         this.guard = new GattStateTransitionValidator<>();
-        this.state = GattState.IDLE;
+        this.state = DEFAULT_STATE;
         this.mainHandler = new Handler(looper);
     }
 
@@ -87,9 +89,11 @@ public class GattServerConnection implements Closeable {
         this.state = state;
     }
 
-    @SuppressWarnings("unused") // API Method
-    void resetStates(){
-        this.setState(GattState.DISCONNECTED);
+    /**
+     * Reset to default connection state
+     */
+    public void resetState(){
+        this.setState(DEFAULT_STATE);
     }
 
     @VisibleForTesting

--- a/src/main/java/com/fitbit/bluetooth/fbgatt/strategies/BluetoothOffClearGattServerStrategy.java
+++ b/src/main/java/com/fitbit/bluetooth/fbgatt/strategies/BluetoothOffClearGattServerStrategy.java
@@ -82,7 +82,7 @@ public class BluetoothOffClearGattServerStrategy extends Strategy {
             } catch (NullPointerException e) {
                 Timber.w(e, "There was an internal stack NPE, the Android BluetoothService probably crashed or already shut down");
             }
-            serverConn.setState(GattState.IDLE);
+            serverConn.resetState();
         });
     }
 }

--- a/src/main/java/com/fitbit/bluetooth/fbgatt/strategies/HandleTrackerVanishingUnderGattOperationStrategy.java
+++ b/src/main/java/com/fitbit/bluetooth/fbgatt/strategies/HandleTrackerVanishingUnderGattOperationStrategy.java
@@ -8,18 +8,19 @@
 
 package com.fitbit.bluetooth.fbgatt.strategies;
 
+import android.bluetooth.BluetoothGatt;
+import androidx.annotation.Nullable;
 import com.fitbit.bluetooth.fbgatt.AndroidDevice;
 import com.fitbit.bluetooth.fbgatt.FitbitGatt;
 import com.fitbit.bluetooth.fbgatt.GattConnection;
+import com.fitbit.bluetooth.fbgatt.GattServerConnection;
 import com.fitbit.bluetooth.fbgatt.GattState;
-import android.bluetooth.BluetoothGatt;
 import java.util.concurrent.TimeUnit;
-import androidx.annotation.Nullable;
 import timber.log.Timber;
 
 /**
  * In the case that we have a tracker that has disconnected, in the middle of a write / read /
- * server response, we should mark that connection as disconnected and force the timeout wait with
+ * server response, we should reset that connection and force the timeout wait with
  * a 133 unknown ( connection interface unknown ) gatt status.
  */
 
@@ -49,9 +50,10 @@ public class HandleTrackerVanishingUnderGattOperationStrategy extends Strategy {
         Timber.v("Waiting %dms for the client_if to dump", WAIT_TIME_FOR_DISCONNECTION);
         if (connection != null) {
             connection.getMainHandler().postDelayed(() -> {
-                connection.setState(GattState.DISCONNECTED);
-                if (FitbitGatt.getInstance().getServer() != null) {
-                    FitbitGatt.getInstance().getServer().setState(GattState.DISCONNECTED);
+                connection.resetState();
+                GattServerConnection server = FitbitGatt.getInstance().getServer();
+                if (server != null) {
+                    server.resetState();
                 }
                 Timber.v("Strategy is done, gatt can be used again");
             }, WAIT_TIME_FOR_DISCONNECTION);

--- a/src/main/java/com/fitbit/bluetooth/fbgatt/tx/AddGattServerServiceCharacteristicDescriptorTransaction.java
+++ b/src/main/java/com/fitbit/bluetooth/fbgatt/tx/AddGattServerServiceCharacteristicDescriptorTransaction.java
@@ -112,7 +112,7 @@ public class AddGattServerServiceCharacteristicDescriptorTransaction extends Gat
                 .descriptorUuid(descriptor.getUuid())
                 .resultStatus(TransactionResult.TransactionResultStatus.FAILURE);
         callCallbackWithTransactionResultAndRelease(callback, builder.build());
-        getGattServer().setState(GattState.IDLE);
+        getGattServer().resetState();
     }
 
     /**

--- a/src/main/java/com/fitbit/bluetooth/fbgatt/tx/AddGattServerServiceCharacteristicTransaction.java
+++ b/src/main/java/com/fitbit/bluetooth/fbgatt/tx/AddGattServerServiceCharacteristicTransaction.java
@@ -70,7 +70,7 @@ public class AddGattServerServiceCharacteristicTransaction extends GattServerTra
                             .characteristicUuid(characteristic.getUuid())
                             .resultStatus(TransactionResult.TransactionResultStatus.FAILURE);
                     callCallbackWithTransactionResultAndRelease(callback, builder.build());
-                    getGattServer().setState(GattState.IDLE);
+                    getGattServer().resetState();
                     return;
                 }
                 addCriticalDescriptorsIfNecessary(characteristic);
@@ -84,7 +84,7 @@ public class AddGattServerServiceCharacteristicTransaction extends GattServerTra
                             .characteristicUuid(characteristic.getUuid())
                             .resultStatus(TransactionResult.TransactionResultStatus.SUCCESS);
                     callCallbackWithTransactionResultAndRelease(callback, builder.build());
-                    getGattServer().setState(GattState.IDLE);
+                    getGattServer().resetState();
                 } else {
                     respondWithError("Couldn't add the characteristic to the local gatt service", callback);
                 }
@@ -124,7 +124,7 @@ public class AddGattServerServiceCharacteristicTransaction extends GattServerTra
         builder.gattState(getGattServer().getGattState())
                 .resultStatus(TransactionResult.TransactionResultStatus.FAILURE);
         callCallbackWithTransactionResultAndRelease(callback, builder.build());
-        getGattServer().setState(GattState.IDLE);
+        getGattServer().resetState();
     }
 
     /**

--- a/src/main/java/com/fitbit/bluetooth/fbgatt/tx/AddGattServerServiceTransaction.java
+++ b/src/main/java/com/fitbit/bluetooth/fbgatt/tx/AddGattServerServiceTransaction.java
@@ -71,7 +71,7 @@ public class AddGattServerServiceTransaction extends GattServerTransaction {
                         .serviceUuid(service.getUuid())
                         .resultStatus(TransactionResult.TransactionResultStatus.FAILURE);
                 callCallbackWithTransactionResultAndRelease(callback, builder.build());
-                getGattServer().setState(GattState.IDLE);
+                getGattServer().resetState();
                 return;
             }
             boolean success = false;
@@ -92,7 +92,7 @@ public class AddGattServerServiceTransaction extends GattServerTransaction {
                     .serviceUuid(service.getUuid())
                     .resultStatus(TransactionResult.TransactionResultStatus.FAILURE);
                 callCallbackWithTransactionResultAndRelease(callback, builder.build());
-                getGattServer().setState(GattState.IDLE);
+                getGattServer().resetState();
             }
         }
     }
@@ -107,17 +107,15 @@ public class AddGattServerServiceTransaction extends GattServerTransaction {
             builder.gattState(getGattServer().getGattState())
                     .serviceUuid(service.getUuid())
                     .resultStatus(TransactionResult.TransactionResultStatus.SUCCESS);
-            callCallbackWithTransactionResultAndRelease(callback, builder.build());
-            getGattServer().setState(GattState.IDLE);
         } else {
             getGattServer().setState(GattState.ADD_SERVICE_FAILURE);
             Timber.e("The gatt service could not be added: %s", service.getUuid());
             builder.gattState(getGattServer().getGattState())
                     .serviceUuid(service.getUuid())
                     .resultStatus(TransactionResult.TransactionResultStatus.FAILURE);
-            callCallbackWithTransactionResultAndRelease(callback, builder.build());
-            getGattServer().setState(GattState.IDLE);
         }
+        callCallbackWithTransactionResultAndRelease(callback, builder.build());
+        getGattServer().resetState();
     }
 
     /**
@@ -127,7 +125,8 @@ public class AddGattServerServiceTransaction extends GattServerTransaction {
      */
 
     private boolean doesGattServerServiceAlreadyExist(BluetoothGattService service) {
-        return FitbitGatt.getInstance().getServer().getServer().getService(service.getUuid()) != null;
+        GattServerConnection connection = FitbitGatt.getInstance().getServer();
+        return connection!= null && connection.getServer().getService(service.getUuid()) != null;
     }
 
     @Override

--- a/src/main/java/com/fitbit/bluetooth/fbgatt/tx/ClearServerServicesTransaction.java
+++ b/src/main/java/com/fitbit/bluetooth/fbgatt/tx/ClearServerServicesTransaction.java
@@ -41,7 +41,7 @@ public class ClearServerServicesTransaction extends GattServerTransaction {
                 .resultStatus(TransactionResult.TransactionResultStatus.SUCCESS);
         mainThreadHandler.post(() -> {
             callCallbackWithTransactionResultAndRelease(callback, builder.build());
-            getGattServer().setState(GattState.IDLE);
+            getGattServer().resetState();
         });
     }
 

--- a/src/main/java/com/fitbit/bluetooth/fbgatt/tx/CloseGattServerTransaction.java
+++ b/src/main/java/com/fitbit/bluetooth/fbgatt/tx/CloseGattServerTransaction.java
@@ -53,7 +53,7 @@ public class CloseGattServerTransaction extends GattServerTransaction {
                 .resultStatus(TransactionResult.TransactionResultStatus.FAILURE);
             mainThreadHandler.post(() -> {
                 callCallbackWithTransactionResultAndRelease(callback, builder.build());
-                getGattServer().setState(GattState.IDLE);
+                getGattServer().resetState();
             });
         } else {
             BluetoothUtils bluetoothUtils = new BluetoothUtils();
@@ -67,7 +67,7 @@ public class CloseGattServerTransaction extends GattServerTransaction {
                     .resultStatus(TransactionResult.TransactionResultStatus.SUCCESS);
                 mainThreadHandler.post(() -> {
                     callCallbackWithTransactionResultAndRelease(callback, builder.build());
-                    getGattServer().setState(GattState.IDLE);
+                    getGattServer().resetState();
                 });
             } catch (NullPointerException ex) {
                 Timber.w("As the client close can sometimes NPE internally, it is reasonable to assume that a similar thing occurred for the server");
@@ -76,7 +76,7 @@ public class CloseGattServerTransaction extends GattServerTransaction {
                     .resultStatus(TransactionResult.TransactionResultStatus.FAILURE);
                 mainThreadHandler.post(() -> {
                     callCallbackWithTransactionResultAndRelease(callback, builder.build());
-                    getGattServer().setState(GattState.IDLE);
+                    getGattServer().resetState();
                 });
             }
         }

--- a/src/main/java/com/fitbit/bluetooth/fbgatt/tx/GattServerConnectTransaction.java
+++ b/src/main/java/com/fitbit/bluetooth/fbgatt/tx/GattServerConnectTransaction.java
@@ -65,14 +65,16 @@ public class GattServerConnectTransaction extends GattServerTransaction {
                 builder.resultStatus(TransactionResult.TransactionResultStatus.FAILURE)
                         .gattState(getGattServer().getGattState());
                 callCallbackWithTransactionResultAndRelease(callback, builder.build());
-                getGattServer().setState(GattState.IDLE);
+                // reset state after communicating failure
+                getGattServer().resetState();
             }
         } else {
             getGattServer().setState(GattState.FAILURE_CONNECTING);
             builder.resultStatus(TransactionResult.TransactionResultStatus.FAILURE)
                     .gattState(getGattServer().getGattState());
             callCallbackWithTransactionResultAndRelease(callback, builder.build());
-            getGattServer().setState(GattState.DISCONNECTED);
+            // reset state after communicating failure
+            getGattServer().resetState();
         }
     }
 

--- a/src/main/java/com/fitbit/bluetooth/fbgatt/tx/GattServerDisconnectTransaction.java
+++ b/src/main/java/com/fitbit/bluetooth/fbgatt/tx/GattServerDisconnectTransaction.java
@@ -63,6 +63,7 @@ public class GattServerDisconnectTransaction extends GattServerTransaction {
                 builder.gattState(getGattServer().getGattState())
                         .resultStatus(TransactionResult.TransactionResultStatus.SUCCESS);
                 callCallbackWithTransactionResultAndRelease(callback, builder.build());
+                getGattServer().resetState();
             } else if (newState == BluetoothProfile.STATE_CONNECTED) {
                 getGattServer().setState(GattState.CONNECTED);
                 builder.gattState(getGattServer().getGattState())

--- a/src/main/java/com/fitbit/bluetooth/fbgatt/tx/GetGattServerServicesTransaction.java
+++ b/src/main/java/com/fitbit/bluetooth/fbgatt/tx/GetGattServerServicesTransaction.java
@@ -51,7 +51,7 @@ public class GetGattServerServicesTransaction extends GattServerTransaction {
                 .gattState(getGattServer().getGattState());
         mainThreadHandler.post(() -> {
             callCallbackWithTransactionResultAndRelease(callback, builder.build());
-            getGattServer().setState(GattState.IDLE);
+            getGattServer().resetState();
         });
     }
 

--- a/src/main/java/com/fitbit/bluetooth/fbgatt/tx/NotifyGattServerCharacteristicTransaction.java
+++ b/src/main/java/com/fitbit/bluetooth/fbgatt/tx/NotifyGattServerCharacteristicTransaction.java
@@ -71,7 +71,7 @@ public class NotifyGattServerCharacteristicTransaction extends GattServerTransac
                     .gattState(getGattServer().getGattState());
             mainThreadHandler.post(() -> {
                 callCallbackWithTransactionResultAndRelease(callback, builder.build());
-                getGattServer().setState(GattState.IDLE);
+                getGattServer().resetState();
                 // we want to apply this strategy to every phone, so we will provide an empty target android
                 // device
                 Strategy strategy = strategyProvider.
@@ -96,13 +96,12 @@ public class NotifyGattServerCharacteristicTransaction extends GattServerTransac
         if(status == BluetoothGatt.GATT_SUCCESS) {
             getGattServer().setState(GattState.NOTIFY_CHARACTERISTIC_SUCCESS);
             builder.resultStatus(TransactionResult.TransactionResultStatus.SUCCESS);
-            callCallbackWithTransactionResultAndRelease(callback, builder.build());
-            getGattServer().setState(GattState.IDLE);
         } else {
             getGattServer().setState(GattState.NOTIFY_CHARACTERISTIC_FAILURE);
             builder.resultStatus(TransactionResult.TransactionResultStatus.FAILURE);
-            callCallbackWithTransactionResultAndRelease(callback, builder.build());
         }
+        callCallbackWithTransactionResultAndRelease(callback, builder.build());
+        getGattServer().resetState();
     }
 
     @Override

--- a/src/main/java/com/fitbit/bluetooth/fbgatt/tx/ReadGattServerCharacteristicDescriptorValueTransaction.java
+++ b/src/main/java/com/fitbit/bluetooth/fbgatt/tx/ReadGattServerCharacteristicDescriptorValueTransaction.java
@@ -78,7 +78,7 @@ public class ReadGattServerCharacteristicDescriptorValueTransaction extends Gatt
                         .data(value)
                         .descriptorUuid(localDescriptor.getUuid());
             callCallbackWithTransactionResultAndRelease(callback, builder.build());
-            getGattServer().setState(GattState.IDLE);
+            getGattServer().resetState();
         } else {
             // failure
             respondWithError(localCharacteristic, localDescriptor, callback);
@@ -96,7 +96,7 @@ public class ReadGattServerCharacteristicDescriptorValueTransaction extends Gatt
                 .characteristicUuid(characteristic == null ? null : characteristic.getUuid())
                 .descriptorUuid(descriptor == null ? null : descriptor.getUuid());
         callCallbackWithTransactionResultAndRelease(callback, builder.build());
-        getGattServer().setState(GattState.IDLE);
+        getGattServer().resetState();
     }
 
     @Override

--- a/src/main/java/com/fitbit/bluetooth/fbgatt/tx/ReadGattServerCharacteristicValueTransaction.java
+++ b/src/main/java/com/fitbit/bluetooth/fbgatt/tx/ReadGattServerCharacteristicValueTransaction.java
@@ -65,7 +65,7 @@ public class ReadGattServerCharacteristicValueTransaction extends GattServerTran
                         .serviceUuid(service.getUuid())
                         .characteristicUuid(localCharacteristic.getUuid());
             callCallbackWithTransactionResultAndRelease(callback, builder.build());
-            getGattServer().setState(GattState.IDLE);
+            getGattServer().resetState();
         } else {
             // failure
             respondWithError(localCharacteristic, callback);
@@ -82,7 +82,7 @@ public class ReadGattServerCharacteristicValueTransaction extends GattServerTran
                 .serviceUuid(service.getUuid())
                 .characteristicUuid(characteristic == null ? null : characteristic.getUuid());
         callCallbackWithTransactionResultAndRelease(callback, builder.build());
-        getGattServer().setState(GattState.IDLE);
+        getGattServer().resetState();
     }
 
     @Override

--- a/src/main/java/com/fitbit/bluetooth/fbgatt/tx/RemoveGattServerServicesTransaction.java
+++ b/src/main/java/com/fitbit/bluetooth/fbgatt/tx/RemoveGattServerServicesTransaction.java
@@ -52,7 +52,7 @@ public class RemoveGattServerServicesTransaction extends GattServerTransaction {
         builder.gattState(getGattServer().getGattState());
         mainThreadHandler.post(() -> {
             callCallbackWithTransactionResultAndRelease(callback, builder.build());
-            getGattServer().setState(GattState.IDLE);
+            getGattServer().resetState();
         });
     }
 

--- a/src/main/java/com/fitbit/bluetooth/fbgatt/tx/SendGattServerResponseTransaction.java
+++ b/src/main/java/com/fitbit/bluetooth/fbgatt/tx/SendGattServerResponseTransaction.java
@@ -78,7 +78,7 @@ public class SendGattServerResponseTransaction extends GattServerTransaction {
                     offset(offset);
             mainThreadHandler.post(() -> {
                 callCallbackWithTransactionResultAndRelease(callback, builder.build());
-                getGattServer().setState(GattState.IDLE);
+                getGattServer().resetState();
             });
         } else {
             getGattServer().setState(GattState.SEND_SERVER_RESPONSE_FAILURE);
@@ -90,7 +90,7 @@ public class SendGattServerResponseTransaction extends GattServerTransaction {
                     offset(offset);
             mainThreadHandler.post(() -> {
                 callCallbackWithTransactionResultAndRelease(callback, builder.build());
-                getGattServer().setState(GattState.IDLE);
+                getGattServer().resetState();
                 // we want to apply this strategy to every phone, so we will provide an empty target android
                 // device
                 Strategy strategy = strategyProvider.

--- a/src/main/java/com/fitbit/bluetooth/fbgatt/tx/WriteGattServerCharacteristicDescriptorValueTransaction.java
+++ b/src/main/java/com/fitbit/bluetooth/fbgatt/tx/WriteGattServerCharacteristicDescriptorValueTransaction.java
@@ -83,7 +83,7 @@ public class WriteGattServerCharacteristicDescriptorValueTransaction extends Gat
                         .characteristicUuid(localCharacteristic.getUuid())
                         .descriptorUuid(localDescriptor.getUuid());
                 callCallbackWithTransactionResultAndRelease(callback, builder.build());
-                getGattServer().setState(GattState.IDLE);
+                getGattServer().resetState();
             } else {
                 // failure
                 respondWithError(localCharacteristic, localDescriptor, callback);
@@ -111,7 +111,7 @@ public class WriteGattServerCharacteristicDescriptorValueTransaction extends Gat
                 .characteristicUuid(characteristic == null ? null : characteristic.getUuid())
                 .descriptorUuid(descriptor == null ? null : descriptor.getUuid());
         callCallbackWithTransactionResultAndRelease(callback, builder.build());
-        getGattServer().setState(GattState.IDLE);
+        getGattServer().resetState();
     }
 
     @Override

--- a/src/main/java/com/fitbit/bluetooth/fbgatt/tx/WriteGattServerCharacteristicValueTransaction.java
+++ b/src/main/java/com/fitbit/bluetooth/fbgatt/tx/WriteGattServerCharacteristicValueTransaction.java
@@ -71,7 +71,7 @@ public class WriteGattServerCharacteristicValueTransaction extends GattServerTra
                         .serviceUuid(service.getUuid())
                         .characteristicUuid(localCharacteristic.getUuid());
                 callCallbackWithTransactionResultAndRelease(callback, builder.build());
-                getGattServer().setState(GattState.IDLE);
+                getGattServer().resetState();
             } else {
                 // failure
                 respondWithError(localCharacteristic, callback);
@@ -98,7 +98,7 @@ public class WriteGattServerCharacteristicValueTransaction extends GattServerTra
                 .serviceUuid(service.getUuid())
                 .characteristicUuid(characteristic == null ? null : characteristic.getUuid());
         callCallbackWithTransactionResultAndRelease(callback, builder.build());
-        getGattServer().setState(GattState.IDLE);
+        getGattServer().resetState();
     }
 
     @Override

--- a/src/test/java/com/fitbit/bluetooth/fbgatt/GattTransactionValidatorTest.java
+++ b/src/test/java/com/fitbit/bluetooth/fbgatt/GattTransactionValidatorTest.java
@@ -66,7 +66,7 @@ public class GattTransactionValidatorTest {
 
     @Test
     public void testCanNotEnterTransactionWithBluetoothOff() {
-        conn.resetStates();
+        conn.resetState();
         conn.setState(GattState.BT_OFF);
         GattStateTransitionValidator<GattClientTransaction> validator = new GattStateTransitionValidator<GattClientTransaction>();
         GattConnectMockTransaction tx = new GattConnectMockTransaction(conn, GattState.CONNECTED, false);
@@ -76,7 +76,7 @@ public class GattTransactionValidatorTest {
 
     @Test
     public void testConnectionTransactionValidator() {
-        conn.resetStates();
+        conn.resetState();
         GattStateTransitionValidator<GattClientTransaction> validator = new GattStateTransitionValidator<GattClientTransaction>();
         GattConnectMockTransaction tx = new GattConnectMockTransaction(conn, GattState.CONNECTED, false);
         GattStateTransitionValidator.GuardState guardState = validator.checkTransaction(conn.getGattState(), tx);
@@ -85,7 +85,7 @@ public class GattTransactionValidatorTest {
 
     @Test
     public void testConnectionWhileDisconnectedTransactionValidator() {
-        conn.resetStates();
+        conn.resetState();
         GattStateTransitionValidator<GattClientTransaction> validator = new GattStateTransitionValidator<GattClientTransaction>();
         GattConnectMockTransaction tx = new GattConnectMockTransaction(conn, GattState.CONNECTED, false);
         GattStateTransitionValidator.GuardState guardState = validator.checkTransaction(conn.getGattState(), tx);
@@ -113,7 +113,7 @@ public class GattTransactionValidatorTest {
     @Test
     @Ignore
     public void testAnythingOtherThanConnectWhileDisconnectedTransactionValidator() {
-        conn.resetStates();
+        conn.resetState();
         GattStateTransitionValidator<GattClientTransaction> validator = new GattStateTransitionValidator<GattClientTransaction>();
         ReadGattCharacteristicMockTransaction tx = new ReadGattCharacteristicMockTransaction(conn,
                 GattState.READ_CHARACTERISTIC_SUCCESS,
@@ -128,7 +128,7 @@ public class GattTransactionValidatorTest {
 
     @Test
     public void testSetStateInErrorConditionValidatorTest() {
-        conn.resetStates();
+        conn.resetState();
         conn.setState(GattState.WRITE_CHARACTERISTIC_FAILURE);
         GattStateTransitionValidator<GattClientTransaction> validator = new GattStateTransitionValidator<GattClientTransaction>();
         SetClientConnectionStateTransaction tx = new SetClientConnectionStateTransaction(conn, GattState.GATT_CONNECTION_STATE_SET_SUCCESSFULLY, GattState.IDLE);
@@ -138,7 +138,7 @@ public class GattTransactionValidatorTest {
 
     @Test
     public void testServerDisconnectionTransactionValidator() {
-        conn.resetStates();
+        conn.resetState();
         conn.setState(GattState.CONNECTED);
         GattStateTransitionValidator<GattServerTransaction> validator = new GattStateTransitionValidator<GattServerTransaction>();
         GattServerDisconnectMockTransaction tx = new GattServerDisconnectMockTransaction(serverConnection, GattState.DISCONNECTED, device, false);
@@ -149,7 +149,7 @@ public class GattTransactionValidatorTest {
     @Test
     @Ignore
     public void testSettingTransactionTimeout(){
-        conn.resetStates();
+        conn.resetState();
         conn.setState(GattState.CONNECTED);
         WriteGattCharacteristicMockTransaction writeGattCharacteristicMockTransaction = new WriteGattCharacteristicMockTransaction(conn, GattState.WRITE_CHARACTERISTIC_SUCCESS, new BluetoothGattCharacteristic(UUID.randomUUID(),
                 BluetoothGattCharacteristic.PERMISSION_READ,


### PR DESCRIPTION
Fixes #
232132305
### description
GATT service subscription failure during response due to incorrect server connection state and another NPE fix #70

### changes
- For subscription failure, reset server connection state to Idle(default) after disconnection is complete and state broadcasted
- for NPE, annotate the getter with @Nullable and update usage with null-check

### how tested
TBD
